### PR TITLE
Enhance search with fuzzy matching and highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # VerseReminder
-# VerseReminder
+
+An iOS app for Bible reading and verse tracking.
+
+## Features
+
+- Browse Bible books and chapters
+- Read verses with an API-based loader
+- Smart search for books, chapters, and verses with fuzzy matching and colored results

--- a/StringExtensions.swift
+++ b/StringExtensions.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+extension String {
+    func levenshteinDistance(to target: String) -> Int {
+        let source = Array(self.lowercased())
+        let target = Array(target.lowercased())
+        let (m, n) = (source.count, target.count)
+        var dist = Array(repeating: Array(repeating: 0, count: n + 1), count: m + 1)
+        for i in 0...m { dist[i][0] = i }
+        for j in 0...n { dist[0][j] = j }
+        for i in 1...m {
+            for j in 1...n {
+                if source[i-1] == target[j-1] {
+                    dist[i][j] = dist[i-1][j-1]
+                } else {
+                    dist[i][j] = min(dist[i-1][j-1], dist[i-1][j], dist[i][j-1]) + 1
+                }
+            }
+        }
+        return dist[m][n]
+    }
+
+    func similarityScore(to target: String) -> Double {
+        if self.isEmpty && target.isEmpty { return 1 }
+        let distance = self.levenshteinDistance(to: target)
+        return 1 - Double(distance) / Double(max(self.count, target.count))
+    }
+}


### PR DESCRIPTION
## Summary
- implement Levenshtein-based similarity helpers in `StringExtensions`
- add fuzzy book search and relevance scoring in `OverviewView`
- highlight query matches and color code search rows
- document smart search in the README

## Testing
- `swift --version`
- `swiftc -frontend -typecheck *.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686830416b0c832eb7494c3567f6acab