### PR TITLE
Improve scroll behavior after selecting a book

### DIFF
--- a/OverviewVIew.swift
+++ b/OverviewVIew.swift
@@ -261,7 +261,6 @@ struct OverviewView: View {
                                     withAnimation(.easeInOut(duration: 0.5)) {
                                         proxy.scrollTo(id, anchor: .center)
                                     }
-                                    scrollTargetBookId = nil
                                 }
                             }
                         }
@@ -272,8 +271,17 @@ struct OverviewView: View {
                                     withAnimation(.easeInOut(duration: 0.5)) {
                                         proxy.scrollTo(id, anchor: .center)
                                     }
-                                    scrollTargetBookId = nil
                                 }
+                            }
+                        }
+                        .onChange(of: expandedBookId) { id in
+                            guard let id = id, id == scrollTargetBookId else { return }
+                            // Scroll again after the dropdown expansion animation completes
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                                withAnimation(.easeInOut(duration: 0.5)) {
+                                    proxy.scrollTo(id, anchor: .center)
+                                }
+                                scrollTargetBookId = nil
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- make search result selection keep `scrollTargetBookId` until after the dropdown opens
- add a second scroll triggered by `expandedBookId` change so the opened dropdown is centered

## Testing
- `swiftc --version`

------
https://chatgpt.com/codex/tasks/task_e_68684c1b9318832eb1daad56fcb6fa86