### PR TITLE
Fix search scroll to book

### DIFF
--- a/OverviewVIew.swift
+++ b/OverviewVIew.swift
@@ -257,30 +257,20 @@ struct OverviewView: View {
                         .listStyle(InsetGroupedListStyle())
                         .onChange(of: scrollTargetBookId) { id in
                             if let id = id {
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                    withAnimation(.easeInOut(duration: 0.5)) {
-                                        proxy.scrollTo(id, anchor: .center)
-                                    }
-                                }
+                                attemptScroll(to: id, using: proxy)
                             }
                         }
                         .onChange(of: searchManager.showingSearchResults) { showing in
                             if !showing, let id = scrollTargetBookId {
                                 // When search results are dismissed, ensure we scroll to the target
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                    withAnimation(.easeInOut(duration: 0.5)) {
-                                        proxy.scrollTo(id, anchor: .center)
-                                    }
-                                }
+                                attemptScroll(to: id, using: proxy)
                             }
                         }
                         .onChange(of: expandedBookId) { id in
                             guard let id = id, id == scrollTargetBookId else { return }
                             // Scroll again after the dropdown expansion animation completes
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-                                withAnimation(.easeInOut(duration: 0.5)) {
-                                    proxy.scrollTo(id, anchor: .center)
-                                }
+                                attemptScroll(to: id, using: proxy)
                                 scrollTargetBookId = nil
                             }
                         }
@@ -328,6 +318,17 @@ struct OverviewView: View {
             // Navigate to chapter containing the verse
             selectedChapter = (result.book, result.chapter ?? 1, result.verse)
             searchManager.clearSearch()
+        }
+    }
+
+    private func attemptScroll(to id: String, using proxy: ScrollViewProxy) {
+        let delays: [Double] = [0.1, 0.35, 0.8]
+        for delay in delays {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                withAnimation(.easeInOut(duration: 0.5)) {
+                    proxy.scrollTo(id, anchor: .center)
+                }
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ An iOS app for Bible reading and verse tracking.
   - Handles typos like "Mathew 4:3" and shows both chapter and verse hits
   - Verse results display full text
   - Selecting a book result scrolls to and centers that book in the overview
+  - Book scrolling is more reliable thanks to repeated scroll attempts


### PR DESCRIPTION
## Summary
- reliability improvements for scroll to books when selecting search results
- add repeated scroll attempt helper and call it in scroll-related events
- note improved scroll reliability in README

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68684d9eacbc832eb927386029feaaf1