### PR TITLE
Add book expansion view

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,6 @@ An iOS app for Bible reading and verse tracking.
 - Smart search for books, chapters, and verses with fuzzy matching and colored results
   - Handles typos like "Mathew 4:3" and shows both chapter and verse hits
   - Verse results display full text
-  - Selecting a book result scrolls to and centers that book in the overview
+  - Selecting a book result opens an expanded view listing all chapters in a grid
+  - Book scrolling uses async repeated attempts to reliably center the selected book
+  - Each book dropdown offers an "Expand Book" button for quick access to the grid view


### PR DESCRIPTION
## Summary
- introduce `ExpandedBookView` for a grid listing of chapters
- add "Expand Book" button to book dropdowns
- navigate to expanded view when selecting a book in search
- document the new expanded view in the README

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68684d9eacbc832eb927386029feaaf1