### PR TITLE
Fix expand button navigation

### DIFF
--- a/ExpandedBookView.swift
+++ b/ExpandedBookView.swift
@@ -96,6 +96,9 @@ struct ExpandedBookView: View {
     private func handleSearchResult(_ result: BibleSearchResult) {
         switch result.type {
         case .book:
+            // When selecting another book, clear any pending chapter
+            // navigation to prevent unintended pushes
+            selectedChapter = nil
             selectedBook = result.book
             searchManager.clearSearch()
         case .chapter:

--- a/OverviewVIew.swift
+++ b/OverviewVIew.swift
@@ -242,6 +242,9 @@ struct OverviewView: View {
                                 selectedChapter = (book, chapter, nil)
                             },
                             onExpandBook: { book in
+                                // Ensure chapter navigation is cleared so only the
+                                // expanded book view opens
+                                selectedChapter = nil
                                 selectedExpandedBook = book
                             }
                         )
@@ -256,6 +259,9 @@ struct OverviewView: View {
                                 selectedChapter = (book, chapter, nil)
                             },
                             onExpandBook: { book in
+                                // Clear any pending chapter navigation to avoid
+                                // triggering multiple links
+                                selectedChapter = nil
                                 selectedExpandedBook = book
                             }
                         )
@@ -330,6 +336,8 @@ struct OverviewView: View {
         switch result.type {
         case .book:
             // Navigate to the expanded view for the selected book
+            // Ensure chapter navigation is cleared first
+            selectedChapter = nil
             selectedExpandedBook = result.book
             searchManager.clearSearch()
             


### PR DESCRIPTION
## Summary
- make expand buttons clear any pending chapter selection before showing ExpandedBookView
- ensure search results to books also clear selected chapter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686874bbbd58832eafc28932966db819