### PR TITLE
Fix expand button navigation

### DIFF
--- a/ExpandedBookView.swift
+++ b/ExpandedBookView.swift
@@ -96,6 +96,9 @@ struct ExpandedBookView: View {
     private func handleSearchResult(_ result: BibleSearchResult) {
         switch result.type {
         case .book:
+            // When selecting another book, clear any pending chapter
+            // navigation to prevent unintended pushes
+            selectedChapter = nil
             selectedBook = result.book
             searchManager.clearSearch()
         case .chapter:

--- a/OverviewVIew.swift
+++ b/OverviewVIew.swift
@@ -239,9 +239,15 @@ struct OverviewView: View {
                             chaptersBookmarked: $chaptersBookmarked,
                             lastRead: $lastRead,
                             onSelectChapter: { book, chapter in
+                                // When navigating directly to a chapter, clear
+                                // any active expanded book navigation
+                                selectedExpandedBook = nil
                                 selectedChapter = (book, chapter, nil)
                             },
                             onExpandBook: { book in
+                                // Ensure chapter navigation is cleared so only the
+                                // expanded book view opens
+                                selectedChapter = nil
                                 selectedExpandedBook = book
                             }
                         )
@@ -253,9 +259,14 @@ struct OverviewView: View {
                             chaptersBookmarked: $chaptersBookmarked,
                             lastRead: $lastRead,
                             onSelectChapter: { book, chapter in
+                                // Clear expanded book navigation when moving to a chapter
+                                selectedExpandedBook = nil
                                 selectedChapter = (book, chapter, nil)
                             },
                             onExpandBook: { book in
+                                // Clear any pending chapter navigation to avoid
+                                // triggering multiple links
+                                selectedChapter = nil
                                 selectedExpandedBook = book
                             }
                         )
@@ -330,16 +341,22 @@ struct OverviewView: View {
         switch result.type {
         case .book:
             // Navigate to the expanded view for the selected book
+            // Ensure chapter navigation is cleared first
+            selectedChapter = nil
             selectedExpandedBook = result.book
             searchManager.clearSearch()
             
         case .chapter:
             // Navigate to specific chapter
+            // Clear any active expanded book view before navigating
+            selectedExpandedBook = nil
             selectedChapter = (result.book, result.chapter ?? 1, nil)
             searchManager.clearSearch()
 
         case .verse:
             // Navigate to chapter containing the verse
+            // Ensure only the chapter view is pushed
+            selectedExpandedBook = nil
             selectedChapter = (result.book, result.chapter ?? 1, result.verse)
             searchManager.clearSearch()
         }


### PR DESCRIPTION
## Summary
- clear active ExpandedBookView when navigating to chapters
- ensure search results to chapters also clear expanded view

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686874bbbd58832eafc28932966db819