### PR TITLE
Fix overlapping start button actions

### DIFF
--- a/OverviewVIew.swift
+++ b/OverviewVIew.swift
@@ -723,6 +723,7 @@ struct BookDropdownCell: View {
                                         .background(Color.green)
                                         .cornerRadius(8)
                                     }
+                                    .buttonStyle(PlainButtonStyle())
                                     Button(action: onExpandBook) {
                                         Image(systemName: "arrow.up.left.and.arrow.down.right")
                                             .font(.subheadline.weight(.semibold))
@@ -731,6 +732,7 @@ struct BookDropdownCell: View {
                                             .background(Color.purple)
                                             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                                     }
+                                    .buttonStyle(PlainButtonStyle())
                                 }
                                 .padding(.top, 2)
                             }


### PR DESCRIPTION
## Summary
- prevent start/continue button from triggering expanded book view

## Testing
- `grep -n "buttonStyle(PlainButtonStyle())" -n OverviewVIew.swift`

------
https://chatgpt.com/codex/tasks/task_e_68687859931c832eb03aa01469174308