### PR TITLE
Scope search within ExpandedBookView

### DIFF
--- a/ExpandedBookView.swift
+++ b/ExpandedBookView.swift
@@ -13,7 +13,7 @@ struct ExpandedBookView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SearchBar(searchManager: searchManager)
+            SearchBar(searchManager: searchManager, placeholder: "Search \(book.name) (e.g., 3 or 3:16)")
             if searchManager.showingSearchResults {
                 SearchResultsView(searchManager: searchManager) { result in
                     handleSearchResult(result)
@@ -88,6 +88,11 @@ struct ExpandedBookView: View {
                     set: { if !$0 { selectedBook = nil } }
                 )
             ) { EmptyView() }
+        }
+        .onAppear { searchManager.scopeBook = book }
+        .onDisappear {
+            searchManager.scopeBook = nil
+            searchManager.clearSearch()
         }
         .navigationTitle(book.name)
         .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
## Summary
- add book-specific scope to `BibleSearchManager`
- update `SearchBar` to accept placeholder text
- use book-specific placeholder in `ExpandedBookView`
- limit search results to the current book
- preserve global placeholder in overview view

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*
- `swiftc -typecheck *.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68687aaa9108832e9f91eda6c425d918