### PR TITLE
Add Firebase auth onboarding

### DIFF
--- a/AuthViewModel.swift
+++ b/AuthViewModel.swift
@@ -1,0 +1,92 @@
+import Foundation
+import FirebaseAuth
+import FirebaseFirestore
+
+class AuthViewModel: ObservableObject {
+    @Published var user: User?
+    @Published var isLoading: Bool = true
+    @Published var error: Error?
+
+    private var listener: AuthStateDidChangeListenerHandle?
+    private let dataStore = UserDataStore()
+
+    init() {
+        listener = Auth.auth().addStateDidChangeListener { [weak self] _, user in
+            self?.user = user
+        }
+        signInAnonymouslyIfNeeded()
+    }
+
+    deinit {
+        if let listener = listener {
+            Auth.auth().removeStateDidChangeListener(listener)
+        }
+    }
+
+    func signInAnonymouslyIfNeeded() {
+        isLoading = true
+        if Auth.auth().currentUser == nil {
+            Auth.auth().signInAnonymously { [weak self] result, error in
+                DispatchQueue.main.async {
+                    self?.isLoading = false
+                    if let error = error {
+                        self?.error = error
+                    } else {
+                        self?.user = result?.user
+                    }
+                }
+            }
+        } else {
+            self.user = Auth.auth().currentUser
+            self.isLoading = false
+        }
+    }
+
+    func linkWithGoogle(completion: @escaping (Error?) -> Void) {
+        guard let topVC = UIApplication.shared.windows.first?.rootViewController else {
+            completion(NSError(domain: "UI", code: -1, userInfo: [NSLocalizedDescriptionKey: "No Root VC"]))
+            return
+        }
+        GIDSignIn.sharedInstance.signIn(withPresenting: topVC) { result, error in
+            if let error = error {
+                completion(error)
+                return
+            }
+            guard let token = result?.user.idToken?.tokenString,
+                  let accessToken = result?.user.accessToken
+            else {
+                completion(NSError(domain: "Auth", code: -1, userInfo: [NSLocalizedDescriptionKey: "Missing token"]))
+                return
+            }
+            let credential = GoogleAuthProvider.credential(withIDToken: token, accessToken: accessToken)
+            self.link(with: credential, completion: completion)
+        }
+    }
+
+    func linkWithEmail(email: String, password: String, completion: @escaping (Error?) -> Void) {
+        let credential = EmailAuthProvider.credential(withEmail: email, password: password)
+        link(with: credential, completion: completion)
+    }
+
+    func link(with credential: AuthCredential, completion: @escaping (Error?) -> Void) {
+        guard let user = Auth.auth().currentUser else {
+            completion(NSError(domain: "Auth", code: -1, userInfo: [NSLocalizedDescriptionKey: "No current user"]))
+            return
+        }
+        user.link(with: credential) { result, error in
+            DispatchQueue.main.async {
+                if let result = result {
+                    self.user = result.user
+                    completion(nil)
+                } else {
+                    completion(error)
+                }
+            }
+        }
+    }
+
+    func saveProgress(_ progress: [String: Any]) {
+        guard let uid = user?.uid else { return }
+        dataStore.saveProgress(progress, uid: uid, completion: nil)
+    }
+}

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -17,6 +17,15 @@ struct ContentView: View {
                     Image(systemName: "book.closed")
                     Text("Books")
                 }
+
+                // Settings tab
+                NavigationView {
+                    SettingsView()
+                }
+                .tabItem {
+                    Image(systemName: "gear")
+                    Text("Settings")
+                }
             }
         }
     }

--- a/FirebaseAppDelegate.swift
+++ b/FirebaseAppDelegate.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+import FirebaseCore
+
+class FirebaseAppDelegate: NSObject, UIApplicationDelegate {
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        FirebaseApp.configure()
+        return true
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 An iOS app for Bible reading and verse tracking.
 
+## Onboarding & Authentication
+
+The app automatically signs users in anonymously with Firebase on first launch.
+Progress is stored in Firestore under the user's UID. The Settings tab lets
+anonymous users link their account to Google or email using Firebase's `link`
+API so progress can be synced across devices.
+
 ## Features
 
 - Browse Bible books and chapters

--- a/RootView.swift
+++ b/RootView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+import FirebaseAuth
+
+struct RootView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+
+    var body: some View {
+        Group {
+            if authViewModel.isLoading {
+                ProgressView()
+            } else if authViewModel.user != nil {
+                ContentView()
+            } else {
+                Text("Unable to sign in")
+            }
+        }
+    }
+}

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+import FirebaseAuth
+
+struct SettingsView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @State private var showSignInSheet = false
+
+    var body: some View {
+        List {
+            if let user = authViewModel.user {
+                if user.isAnonymous {
+                    Button("Sign in to sync your progress") {
+                        showSignInSheet = true
+                    }
+                } else {
+                    Section(header: Text("Account")) {
+                        Text("Signed in as \(user.email ?? user.uid)")
+                    }
+                }
+            }
+        }
+        .navigationTitle("Settings")
+        .sheet(isPresented: $showSignInSheet) {
+            SignInOptionsView()
+                .environmentObject(authViewModel)
+        }
+    }
+}
+
+struct SignInOptionsView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @Environment(\.dismiss) var dismiss
+    @State private var email = ""
+    @State private var password = ""
+    @State private var showEmailForm = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 16) {
+                if let message = errorMessage {
+                    Text(message).foregroundColor(.red)
+                }
+                Button("Sign in with Google") {
+                    authViewModel.linkWithGoogle { error in
+                        if let error = error {
+                            errorMessage = error.localizedDescription
+                        } else {
+                            dismiss()
+                        }
+                    }
+                }
+                Button("Sign in with Email") {
+                    showEmailForm = true
+                }
+                .sheet(isPresented: $showEmailForm) {
+                    NavigationView {
+                        Form {
+                            TextField("Email", text: $email)
+                                .keyboardType(.emailAddress)
+                            SecureField("Password", text: $password)
+                            if let message = errorMessage {
+                                Text(message).foregroundColor(.red)
+                            }
+                            Button("Link Account") {
+                                authViewModel.linkWithEmail(email: email, password: password) { error in
+                                    if let error = error {
+                                        errorMessage = error.localizedDescription
+                                    } else {
+                                        dismiss()
+                                    }
+                                }
+                            }
+                        }
+                        .navigationTitle("Email Sign In")
+                        .toolbar {
+                            ToolbarItem(placement: .cancellationAction) {
+                                Button("Cancel") { showEmailForm = false }
+                            }
+                        }
+                    }
+                }
+            }
+            .padding()
+            .navigationTitle("Sign In")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Close") { dismiss() } }
+            }
+        }
+    }
+}

--- a/UserDataStore.swift
+++ b/UserDataStore.swift
@@ -1,0 +1,22 @@
+import Foundation
+import FirebaseFirestore
+
+class UserDataStore {
+    private let db = Firestore.firestore()
+
+    func saveProgress(_ progress: [String: Any], uid: String, completion: ((Error?) -> Void)?) {
+        db.collection("users").document(uid).setData(progress, merge: true) { error in
+            completion?(error)
+        }
+    }
+
+    func loadProgress(uid: String, completion: @escaping ([String: Any]?, Error?) -> Void) {
+        db.collection("users").document(uid).getDocument { snapshot, error in
+            if let data = snapshot?.data() {
+                completion(data, nil)
+            } else {
+                completion(nil, error)
+            }
+        }
+    }
+}

--- a/Verse_ReminderApp.swift
+++ b/Verse_ReminderApp.swift
@@ -6,12 +6,17 @@
 //
 
 import SwiftUI
+import FirebaseCore
 
 @main
 struct Verse_ReminderApp: App {
+    @UIApplicationDelegateAdaptor(FirebaseAppDelegate.self) var delegate
+    @StateObject private var authViewModel = AuthViewModel()
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            RootView()
+                .environmentObject(authViewModel)
         }
     }
 }


### PR DESCRIPTION
## Summary
- initialize Firebase in `Verse_ReminderApp` using an app delegate
- create `AuthViewModel` to manage anonymous sign‑in and linking accounts
- show new settings UI for linking Google or email
- add Firestore `UserDataStore`
- route startup through `RootView` which waits for auth state
- update main tab view with a new Settings tab
- mention onboarding in README

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_686883aaa490832e9cc9e9d48e1931be