### PR TITLE
Add swipable chapter completion toggle

### DIFF
--- a/ViewModels/AuthViewModel.swift
+++ b/ViewModels/AuthViewModel.swift
@@ -134,4 +134,18 @@ class AuthViewModel: ObservableObject {
         profile.lastRead[bookId] = ["chapter": chapter, "verse": verse]
         saveProfile()
     }
+
+    func updateLastRead(bookId: String, chapter: Int, verse: Int) {
+        profile.lastRead[bookId] = ["chapter": chapter, "verse": verse]
+        saveProfile()
+    }
+
+    func unmarkChapterRead(bookId: String, chapter: Int) {
+        var set = Set(profile.chaptersRead[bookId] ?? [])
+        if set.contains(chapter) {
+            set.remove(chapter)
+            profile.chaptersRead[bookId] = Array(set).sorted()
+            saveProfile()
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add a helper for updating lastRead and removing a chapter from progress
- add swipeable `CompleteChapterToggle` to `ChapterView`
- enable navigation to next/previous chapters
- update chapter loading to show completion state and store last read

## Testing
- `swiftc --version`
- `swiftc Views/ChapterView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686894fcf0a8832eacb1c86d942ded9c