### PR TITLE
Add swipable chapter completion toggle

### DIFF
--- a/ViewModels/AuthViewModel.swift
+++ b/ViewModels/AuthViewModel.swift
@@ -134,4 +134,18 @@ class AuthViewModel: ObservableObject {
         profile.lastRead[bookId] = ["chapter": chapter, "verse": verse]
         saveProfile()
     }
+
+    func updateLastRead(bookId: String, chapter: Int, verse: Int) {
+        profile.lastRead[bookId] = ["chapter": chapter, "verse": verse]
+        saveProfile()
+    }
+
+    func unmarkChapterRead(bookId: String, chapter: Int) {
+        var set = Set(profile.chaptersRead[bookId] ?? [])
+        if set.contains(chapter) {
+            set.remove(chapter)
+            profile.chaptersRead[bookId] = Array(set).sorted()
+            saveProfile()
+        }
+    }
 }

--- a/Views/ExpandedBookView.swift
+++ b/Views/ExpandedBookView.swift
@@ -8,6 +8,8 @@ struct ExpandedBookView: View {
     let lastRead: [String: (chapter: Int, verse: Int)]
     let onSelectChapter: (BibleBook, Int) -> Void
 
+    @Environment(\.dismiss) private var dismiss
+
     @State private var selectedChapter: (book: BibleBook, chapter: Int, verse: Int?)? = nil
     @State private var selectedBook: BibleBook? = nil
 
@@ -96,6 +98,17 @@ struct ExpandedBookView: View {
         }
         .navigationTitle(book.name)
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(action: backToBooks) {
+                    HStack {
+                        Image(systemName: "chevron.backward")
+                        Text("Books")
+                    }
+                }
+            }
+        }
     }
 
     private func handleSearchResult(_ result: BibleSearchResult) {
@@ -113,6 +126,11 @@ struct ExpandedBookView: View {
             selectedChapter = (result.book, result.chapter ?? 1, result.verse)
             searchManager.clearSearch()
         }
+    }
+
+    private func backToBooks() {
+        dismiss()
+        DispatchQueue.main.async { dismiss() }
     }
 }
 


### PR DESCRIPTION
## Summary
- add a helper for updating lastRead and removing a chapter from progress
- add swipeable `CompleteChapterToggle` to `ChapterView`
- enable navigation to next/previous chapters
- update chapter loading to show completion state and store last read
- style the completion control in black/white and make it swipable
- add a persistent "Back to Books" button that pops to the root view

## Testing
- `swiftc --version`
- `swiftc Views/ChapterView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686894fcf0a8832eacb1c86d942ded9c