### PR TITLE
Add book header actions and improved navigation

### DIFF
--- a/Views/ChapterView.swift
+++ b/Views/ChapterView.swift
@@ -14,11 +14,13 @@ struct ChapterView: View {
     @State private var highlightedVerseId: String? = nil
     @State private var isCompleted: Bool = false
     @State private var navigateToNext: (bookId: String, chapter: Int)? = nil
+    @State private var navigateToBook: BibleBook? = nil
+    @StateObject private var searchManager = BibleSearchManager()
 
     // Heading components
     var bookName: String {
-        // Optional: Map abbreviation to name, or just display abbreviation for now
-        chapterId.components(separatedBy: ".").first ?? ""
+        let abbrev = chapterId.components(separatedBy: ".").first ?? ""
+        return allBooks.first(where: { $0.id == abbrev })?.name ?? abbrev
     }
     var chapterNumber: String {
         chapterId.components(separatedBy: ".").last ?? ""
@@ -48,10 +50,13 @@ struct ChapterView: View {
                 
                 Spacer()
                 
-                Text("\(bookName) \(chapterNumber)")
-                    .font(.title2)
-                    .bold()
-                    .padding(.vertical, 8)
+                Button(action: openExpandedBook) {
+                    Text("\(bookName) \(chapterNumber)")
+                        .font(.title2)
+                        .bold()
+                        .padding(.vertical, 8)
+                }
+                .buttonStyle(PlainButtonStyle())
                 
                 Spacer()
                 
@@ -132,6 +137,26 @@ struct ChapterView: View {
             isActive: Binding(
                 get: { navigateToNext != nil },
                 set: { if !$0 { navigateToNext = nil } }
+            )
+        ) { EmptyView() }
+
+        NavigationLink(
+            destination: navigateToBook.map { book in
+                ExpandedBookView(
+                    book: book,
+                    searchManager: searchManager,
+                    chaptersRead: authViewModel.profile.chaptersRead.mapValues { Set($0) },
+                    chaptersBookmarked: authViewModel.profile.chaptersBookmarked.mapValues { Set($0) },
+                    lastRead: authViewModel.profile.lastRead.reduce(into: [String: (chapter: Int, verse: Int)]()) { partial, item in
+                        partial[item.key] = (item.value["chapter"] ?? 1, item.value["verse"] ?? 0)
+                    }
+                ) { b, chapter in
+                    navigateToNext = (b.id, chapter)
+                }
+            },
+            isActive: Binding(
+                get: { navigateToBook != nil },
+                set: { if !$0 { navigateToBook = nil } }
             )
         ) { EmptyView() }
     }
@@ -234,8 +259,17 @@ struct ChapterView: View {
     }
 
     private func backToBooks() {
-        dismiss()
-        DispatchQueue.main.async { dismiss() }
+        for i in 0..<5 {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Double(i) * 0.05) {
+                dismiss()
+            }
+        }
+    }
+
+    private func openExpandedBook() {
+        if let book = allBooks.first(where: { $0.id == bookId }) {
+            navigateToBook = book
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- show full book names in chapter headers
- allow tapping the chapter header to open the expanded book view
- always pop to the Books overview when tapping the Books back button

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6869862d04a0832ebf6a948969658ca4