### PR TITLE
Add book header actions and improved navigation

### DIFF
--- a/Views/ExpandedBookView.swift
+++ b/Views/ExpandedBookView.swift
@@ -101,11 +101,16 @@ struct ExpandedBookView: View {
         .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                Button(action: backToBooks) {
+                Button(action: { dismiss() }) {
                     HStack {
                         Image(systemName: "chevron.backward")
-                        Text("Books")
+                        Text("Back")
                     }
+                }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: backToBooks) {
+                    Image(systemName: "book.closed")
                 }
             }
         }
@@ -129,8 +134,11 @@ struct ExpandedBookView: View {
     }
 
     private func backToBooks() {
-        dismiss()
-        DispatchQueue.main.async { dismiss() }
+        for i in 0..<5 {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Double(i) * 0.05) {
+                dismiss()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- show full book names in chapter headers
- allow tapping the chapter header to open the expanded book view
- always pop to the Books overview when tapping the Books home button
- use a normal Back button and add a Books home icon on the right

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6869862d04a0832ebf6a948969658ca4