### PR TITLE
Add navigation manager and fix Books home button

### DIFF
--- a/ViewModels/BooksNavigationManager.swift
+++ b/ViewModels/BooksNavigationManager.swift
@@ -1,0 +1,16 @@
+import Foundation
+import SwiftUI
+
+/// Observable object that allows views in the Books navigation stack
+/// to programmatically pop back to the root "Books" page.
+class BooksNavigationManager: ObservableObject {
+    /// Changing this value notifies all views to dismiss themselves.
+    @Published private(set) var resetTrigger: Int = 0
+
+    /// Call to trigger a pop-to-root of all active views in the Books stack.
+    func popToRoot() {
+        // Increment the trigger which will be observed by each view
+        // and cause it to call `dismiss()`.
+        resetTrigger += 1
+    }
+}

--- a/Views/ChapterView.swift
+++ b/Views/ChapterView.swift
@@ -6,6 +6,7 @@ struct ChapterView: View {
     let highlightVerse: Int?
 
     @EnvironmentObject var authViewModel: AuthViewModel
+    @EnvironmentObject var booksNav: BooksNavigationManager
     @Environment(\.dismiss) private var dismiss
     
     @State private var verses: [Verse] = []
@@ -14,11 +15,13 @@ struct ChapterView: View {
     @State private var highlightedVerseId: String? = nil
     @State private var isCompleted: Bool = false
     @State private var navigateToNext: (bookId: String, chapter: Int)? = nil
+    @State private var navigateToBook: BibleBook? = nil
+    @StateObject private var searchManager = BibleSearchManager()
 
     // Heading components
     var bookName: String {
-        // Optional: Map abbreviation to name, or just display abbreviation for now
-        chapterId.components(separatedBy: ".").first ?? ""
+        let abbrev = chapterId.components(separatedBy: ".").first ?? ""
+        return allBooks.first(where: { $0.id == abbrev })?.name ?? abbrev
     }
     var chapterNumber: String {
         chapterId.components(separatedBy: ".").last ?? ""
@@ -48,10 +51,13 @@ struct ChapterView: View {
                 
                 Spacer()
                 
-                Text("\(bookName) \(chapterNumber)")
-                    .font(.title2)
-                    .bold()
-                    .padding(.vertical, 8)
+                Button(action: openExpandedBook) {
+                    Text("\(bookName) \(chapterNumber)")
+                        .font(.title2)
+                        .bold()
+                        .padding(.vertical, 8)
+                }
+                .buttonStyle(PlainButtonStyle())
                 
                 Spacer()
                 
@@ -109,14 +115,22 @@ struct ChapterView: View {
             }
         }
         .onAppear(perform: loadChapter)
+        .onReceive(booksNav.$resetTrigger) { _ in
+            dismiss()
+        }
         .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                Button(action: backToBooks) {
+                Button(action: { dismiss() }) {
                     HStack {
                         Image(systemName: "chevron.backward")
-                        Text("Books")
+                        Text("Back")
                     }
+                }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: backToBooks) {
+                    Image(systemName: "book.closed")
                 }
             }
         }
@@ -132,6 +146,26 @@ struct ChapterView: View {
             isActive: Binding(
                 get: { navigateToNext != nil },
                 set: { if !$0 { navigateToNext = nil } }
+            )
+        ) { EmptyView() }
+
+        NavigationLink(
+            destination: navigateToBook.map { book in
+                ExpandedBookView(
+                    book: book,
+                    searchManager: searchManager,
+                    chaptersRead: authViewModel.profile.chaptersRead.mapValues { Set($0) },
+                    chaptersBookmarked: authViewModel.profile.chaptersBookmarked.mapValues { Set($0) },
+                    lastRead: authViewModel.profile.lastRead.reduce(into: [String: (chapter: Int, verse: Int)]()) { partial, item in
+                        partial[item.key] = (item.value["chapter"] ?? 1, item.value["verse"] ?? 0)
+                    }
+                ) { b, chapter in
+                    navigateToNext = (b.id, chapter)
+                }
+            },
+            isActive: Binding(
+                get: { navigateToBook != nil },
+                set: { if !$0 { navigateToBook = nil } }
             )
         ) { EmptyView() }
     }
@@ -234,8 +268,13 @@ struct ChapterView: View {
     }
 
     private func backToBooks() {
-        dismiss()
-        DispatchQueue.main.async { dismiss() }
+        booksNav.popToRoot()
+    }
+
+    private func openExpandedBook() {
+        if let book = allBooks.first(where: { $0.id == bookId }) {
+            navigateToBook = book
+        }
     }
 }
 

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var booksNavigationManager = BooksNavigationManager()
 
     var body: some View {
         ZStack {
@@ -19,6 +20,7 @@ struct ContentView: View {
                             OverviewView()
                         }
                     }
+                    .environmentObject(booksNavigationManager)
                 }
                 .tabItem {
                     Image(systemName: "book.closed")

--- a/Views/ExpandedBookView.swift
+++ b/Views/ExpandedBookView.swift
@@ -8,6 +8,7 @@ struct ExpandedBookView: View {
     let lastRead: [String: (chapter: Int, verse: Int)]
     let onSelectChapter: (BibleBook, Int) -> Void
 
+    @EnvironmentObject var booksNav: BooksNavigationManager
     @Environment(\.dismiss) private var dismiss
 
     @State private var selectedChapter: (book: BibleBook, chapter: Int, verse: Int?)? = nil
@@ -92,6 +93,9 @@ struct ExpandedBookView: View {
             ) { EmptyView() }
         }
         .onAppear { searchManager.scopeBook = book }
+        .onReceive(booksNav.$resetTrigger) { _ in
+            dismiss()
+        }
         .onDisappear {
             searchManager.scopeBook = nil
             searchManager.clearSearch()
@@ -101,11 +105,16 @@ struct ExpandedBookView: View {
         .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                Button(action: backToBooks) {
+                Button(action: { dismiss() }) {
                     HStack {
                         Image(systemName: "chevron.backward")
-                        Text("Books")
+                        Text("Back")
                     }
+                }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: backToBooks) {
+                    Image(systemName: "book.closed")
                 }
             }
         }
@@ -129,8 +138,7 @@ struct ExpandedBookView: View {
     }
 
     private func backToBooks() {
-        dismiss()
-        DispatchQueue.main.async { dismiss() }
+        booksNav.popToRoot()
     }
 }
 


### PR DESCRIPTION
## Summary
- add `BooksNavigationManager` to coordinate popping to the root Books page
- provide the manager in `ContentView` and subscribe in Chapter and ExpandedBook views
- update Books icon action to use the new navigation manager

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6869862d04a0832ebf6a948969658ca4