### PR TITLE
Improve Books home button behavior

### DIFF
--- a/ViewModels/BooksNavigationManager.swift
+++ b/ViewModels/BooksNavigationManager.swift
@@ -8,9 +8,18 @@ class BooksNavigationManager: ObservableObject {
     @Published private(set) var resetTrigger: Int = 0
 
     /// Call to trigger a pop-to-root of all active views in the Books stack.
+    ///
+    /// To reliably unwind multiple levels of navigation we bump the
+    /// `resetTrigger` several times with small delays. Each active view
+    /// observes this value and dismisses itself when it changes. By
+    /// staggering the increments we ensure that after the top-most view
+    /// closes the next one receives a new trigger and so on.
     func popToRoot() {
-        // Increment the trigger which will be observed by each view
-        // and cause it to call `dismiss()`.
-        resetTrigger += 1
+        let steps = 5
+        for i in 0..<steps {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Double(i) * 0.05) {
+                self.resetTrigger += 1
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- adjust `BooksNavigationManager.popToRoot` to send several navigation reset signals
  - this repeatedly increments `resetTrigger` with tiny delays so each view dismisses sequentially
- keeps existing view logic that observes `resetTrigger`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6869942684cc832e83f87acd223cfcff