### PR TITLE
Improve Books home button behavior

### DIFF
--- a/ViewModels/BooksNavigationManager.swift
+++ b/ViewModels/BooksNavigationManager.swift
@@ -8,9 +8,11 @@ class BooksNavigationManager: ObservableObject {
     @Published private(set) var resetTrigger: Int = 0
 
     /// Call to trigger a pop-to-root of all active views in the Books stack.
+    ///
+    /// Simply incrementing the trigger causes all subscribed views to
+    /// dismiss themselves if the value differs from the one they observed on
+    /// creation. This lets every active panel close simultaneously.
     func popToRoot() {
-        // Increment the trigger which will be observed by each view
-        // and cause it to call `dismiss()`.
         resetTrigger += 1
     }
 }

--- a/Views/ChapterView.swift
+++ b/Views/ChapterView.swift
@@ -17,7 +17,8 @@ struct ChapterView: View {
     @State private var navigateToNext: (bookId: String, chapter: Int)? = nil
     @State private var navigateToBook: BibleBook? = nil
     @StateObject private var searchManager = BibleSearchManager()
-    @State private var hasReceivedTrigger = false
+    // Captures the BooksNavigationManager trigger value on appearance.
+    @State private var initialTrigger: Int? = nil
 
     // Heading components
     var bookName: String {
@@ -116,11 +117,11 @@ struct ChapterView: View {
             }
         }
         .onAppear(perform: loadChapter)
-        .onReceive(booksNav.$resetTrigger) { _ in
-            if hasReceivedTrigger {
-                dismiss()
+        .onReceive(booksNav.$resetTrigger) { val in
+            if let initial = initialTrigger {
+                if val != initial { dismiss() }
             } else {
-                hasReceivedTrigger = true
+                initialTrigger = val
             }
         }
         .navigationBarBackButtonHidden(true)

--- a/Views/ExpandedBookView.swift
+++ b/Views/ExpandedBookView.swift
@@ -13,7 +13,9 @@ struct ExpandedBookView: View {
 
     @State private var selectedChapter: (book: BibleBook, chapter: Int, verse: Int?)? = nil
     @State private var selectedBook: BibleBook? = nil
-    @State private var hasReceivedTrigger = false
+    // Records the trigger value when the view appears so we know when a
+    // subsequent change represents a pop-to-root action.
+    @State private var initialTrigger: Int? = nil
 
     var body: some View {
         VStack(spacing: 0) {
@@ -94,11 +96,11 @@ struct ExpandedBookView: View {
             ) { EmptyView() }
         }
         .onAppear { searchManager.scopeBook = book }
-        .onReceive(booksNav.$resetTrigger) { _ in
-            if hasReceivedTrigger {
-                dismiss()
+        .onReceive(booksNav.$resetTrigger) { val in
+            if let initial = initialTrigger {
+                if val != initial { dismiss() }
             } else {
-                hasReceivedTrigger = true
+                initialTrigger = val
             }
         }
         .onDisappear {


### PR DESCRIPTION
## Summary
- adjust `BooksNavigationManager.popToRoot` to use a single reset trigger increment
- track the initial trigger value in `ChapterView` and `ExpandedBookView`
  - views dismiss when the trigger changes

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6869942684cc832e83f87acd223cfcff