### PR TITLE
Add reading plan and verse bookmark

### DIFF
--- a/Models/ReadingPlan.swift
+++ b/Models/ReadingPlan.swift
@@ -1,0 +1,31 @@
+import FirebaseFirestore
+import Foundation
+
+struct ReadingPlan: Codable {
+    var startDate: Date
+    var chaptersPerWeek: Int
+    var notificationsEnabled: Bool
+
+    var estimatedCompletion: Date {
+        // 1189 chapters in the Bible
+        let weeks = Double(1189) / Double(max(chaptersPerWeek, 1))
+        return Calendar.current.date(byAdding: .day, value: Int(weeks * 7), to: startDate) ?? startDate
+    }
+}
+
+extension ReadingPlan {
+    init?(dict: [String: Any]) {
+        guard let timestamp = dict["startDate"] as? Timestamp else { return nil }
+        startDate = timestamp.dateValue()
+        chaptersPerWeek = dict["chaptersPerWeek"] as? Int ?? 1
+        notificationsEnabled = dict["notificationsEnabled"] as? Bool ?? false
+    }
+
+    var dictionary: [String: Any] {
+        [
+            "startDate": Timestamp(date: startDate),
+            "chaptersPerWeek": chaptersPerWeek,
+            "notificationsEnabled": notificationsEnabled
+        ]
+    }
+}

--- a/Models/UserProfile.swift
+++ b/Models/UserProfile.swift
@@ -4,13 +4,22 @@ struct UserProfile {
     var chaptersRead: [String: [Int]]
     var chaptersBookmarked: [String: [Int]]
     var lastRead: [String: [String: Int]]
+    var readingPlan: ReadingPlan?
+    var continuityBookmark: String?
+    var lastReadBookId: String?
 
     init(chaptersRead: [String: [Int]] = [:],
          chaptersBookmarked: [String: [Int]] = [:],
-         lastRead: [String: [String: Int]] = [:]) {
+         lastRead: [String: [String: Int]] = [:],
+         readingPlan: ReadingPlan? = nil,
+         continuityBookmark: String? = nil,
+         lastReadBookId: String? = nil) {
         self.chaptersRead = chaptersRead
         self.chaptersBookmarked = chaptersBookmarked
         self.lastRead = lastRead
+        self.readingPlan = readingPlan
+        self.continuityBookmark = continuityBookmark
+        self.lastReadBookId = lastReadBookId
     }
 }
 
@@ -19,15 +28,31 @@ extension UserProfile {
         let chaptersRead = dict["chaptersRead"] as? [String: [Int]] ?? [:]
         let chaptersBookmarked = dict["chaptersBookmarked"] as? [String: [Int]] ?? [:]
         let lastRead = dict["lastRead"] as? [String: [String: Int]] ?? [:]
-        self.init(chaptersRead: chaptersRead, chaptersBookmarked: chaptersBookmarked, lastRead: lastRead)
+        var plan: ReadingPlan? = nil
+        if let planData = dict["readingPlan"] as? [String: Any] {
+            plan = ReadingPlan(dict: planData)
+        }
+        let bookmark = dict["continuityBookmark"] as? String
+        let lastBook = dict["lastReadBookId"] as? String
+        self.init(chaptersRead: chaptersRead, chaptersBookmarked: chaptersBookmarked, lastRead: lastRead, readingPlan: plan, continuityBookmark: bookmark, lastReadBookId: lastBook)
     }
 
     var dictionary: [String: Any] {
-        [
+        var dict: [String: Any] = [
             "chaptersRead": chaptersRead,
             "chaptersBookmarked": chaptersBookmarked,
             "lastRead": lastRead
         ]
+        if let plan = readingPlan {
+            dict["readingPlan"] = plan.dictionary
+        }
+        if let bm = continuityBookmark {
+            dict["continuityBookmark"] = bm
+        }
+        if let lastBook = lastReadBookId {
+            dict["lastReadBookId"] = lastBook
+        }
+        return dict
     }
 
     var totalChaptersRead: Int {

--- a/ViewModels/AuthViewModel.swift
+++ b/ViewModels/AuthViewModel.swift
@@ -132,11 +132,13 @@ class AuthViewModel: ObservableObject {
             profile.chaptersRead[bookId] = Array(set).sorted()
         }
         profile.lastRead[bookId] = ["chapter": chapter, "verse": verse]
+        profile.lastReadBookId = bookId
         saveProfile()
     }
 
     func updateLastRead(bookId: String, chapter: Int, verse: Int) {
         profile.lastRead[bookId] = ["chapter": chapter, "verse": verse]
+        profile.lastReadBookId = bookId
         saveProfile()
     }
 
@@ -147,5 +149,15 @@ class AuthViewModel: ObservableObject {
             profile.chaptersRead[bookId] = Array(set).sorted()
             saveProfile()
         }
+    }
+
+    func setReadingPlan(_ plan: ReadingPlan) {
+        profile.readingPlan = plan
+        saveProfile()
+    }
+
+    func setContinuityBookmark(bookId: String, chapter: Int, verse: Int) {
+        profile.continuityBookmark = "\(bookId).\(chapter).\(verse)"
+        saveProfile()
     }
 }

--- a/Views/ChapterView.swift
+++ b/Views/ChapterView.swift
@@ -283,12 +283,27 @@ struct ChapterView: View {
 struct VerseRowView: View {
     let verse: Verse
     let isHighlighted: Bool
+    @EnvironmentObject var authViewModel: AuthViewModel
+
+    var isBookmarked: Bool {
+        authViewModel.profile.continuityBookmark == verse.id
+    }
+
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
-            Text(verse.verseNumber)
-                .bold()
-                .frame(width: 26, alignment: .trailing)
-                .foregroundColor(.secondary)
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(verse.verseNumber)
+                    .bold()
+                    .frame(width: 26, alignment: .trailing)
+                    .foregroundColor(.secondary)
+                if isBookmarked {
+                    Image(systemName: "bookmark.fill")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 10, height: 10)
+                        .foregroundColor(.blue)
+                }
+            }
             Text(verse.cleanedText)
         }
         .padding(.vertical, 2)
@@ -296,6 +311,16 @@ struct VerseRowView: View {
         .background(isHighlighted ? Color.yellow.opacity(0.3) : Color.clear)
         .cornerRadius(6)
         .animation(.easeInOut(duration: 0.3), value: isHighlighted)
+        .contextMenu {
+            Button("Set Continuity Bookmark") {
+                let parts = verse.id.split(separator: ".")
+                if parts.count >= 3,
+                   let chapter = Int(parts[1]),
+                   let verseNum = Int(parts[2]) {
+                    authViewModel.setContinuityBookmark(bookId: String(parts[0]), chapter: chapter, verse: verseNum)
+                }
+            }
+        }
     }
 }
 

--- a/Views/HomeView.swift
+++ b/Views/HomeView.swift
@@ -3,17 +3,52 @@ import SwiftUI
 struct HomeView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
 
+    @State private var showPlanCreator = false
+
     var body: some View {
         NavigationView {
             VStack(alignment: .leading, spacing: 20) {
-                Text("Total chapters read: \(authViewModel.profile.totalChaptersRead)")
-                    .font(.headline)
-                Text("Reading goals coming soon...")
-                    .foregroundColor(.secondary)
+                if let plan = authViewModel.profile.readingPlan {
+                    Text("Total chapters read: \(authViewModel.profile.totalChaptersRead)")
+                        .font(.headline)
+                    Text("Plan: \(plan.chaptersPerWeek) chapters/week")
+                        .foregroundColor(.secondary)
+                    Text("Estimated completion: \(plan.estimatedCompletion, style: .date)")
+                        .font(.caption)
+                    if let last = lastReadReference() {
+                        NavigationLink(destination: ChapterView(chapterId: last.ref, bibleId: defaultBibleId, highlightVerse: last.verse)) {
+                            Text("Continue Reading")
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.green)
+                                .foregroundColor(.white)
+                                .cornerRadius(8)
+                        }
+                    }
+                } else {
+                    VStack(spacing: 12) {
+                        Text("No reading plan yet")
+                        Button("Create Plan") { showPlanCreator = true }
+                            .padding()
+                            .background(Color.blue)
+                            .foregroundColor(.white)
+                            .cornerRadius(8)
+                    }
+                }
                 Spacer()
             }
             .padding()
             .navigationTitle("Home")
+            .sheet(isPresented: $showPlanCreator) {
+                NavigationView { PlanCreatorView() }
+            }
         }
+    }
+
+    private func lastReadReference() -> (ref: String, verse: Int)? {
+        guard let book = authViewModel.profile.lastReadBookId,
+              let info = authViewModel.profile.lastRead[book] else { return nil }
+        let ref = "\(book).\(info["chapter"] ?? 1)"
+        return (ref, info["verse"] ?? 0)
     }
 }

--- a/Views/PlanCreatorView.swift
+++ b/Views/PlanCreatorView.swift
@@ -1,0 +1,49 @@
+import FirebaseFirestore
+import SwiftUI
+
+struct PlanCreatorView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var chaptersPerWeek: Int = 7
+    @State private var notificationsEnabled: Bool = false
+    @State private var startDate: Date = Date()
+
+    var estimatedCompletion: Date {
+        let plan = ReadingPlan(startDate: startDate, chaptersPerWeek: chaptersPerWeek, notificationsEnabled: notificationsEnabled)
+        return plan.estimatedCompletion
+    }
+
+    var body: some View {
+        Form {
+            Section(header: Text("Reading Pace")) {
+                Stepper(value: $chaptersPerWeek, in: 1...50) {
+                    Text("Chapters per week: \(chaptersPerWeek)")
+                }
+                DatePicker("Start Date", selection: $startDate, displayedComponents: .date)
+                Toggle("Enable Notifications", isOn: $notificationsEnabled)
+            }
+
+            Section(header: Text("Estimate")) {
+                Text("Estimated completion: \(estimatedCompletion, style: .date)")
+            }
+        }
+        .navigationTitle("Create Plan")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Save") {
+                    let plan = ReadingPlan(startDate: startDate, chaptersPerWeek: chaptersPerWeek, notificationsEnabled: notificationsEnabled)
+                    authViewModel.setReadingPlan(plan)
+                    dismiss()
+                }
+            }
+        }
+    }
+}
+
+struct PlanCreatorView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlanCreatorView()
+            .environmentObject(AuthViewModel())
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `ReadingPlan` model
- extend `UserProfile` for reading plan, bookmark and last read tracking
- add helpers in `AuthViewModel` to save plans and bookmarks
- implement plan creation UI and show status on Home screen
- enable long‑press context menu on verses to set a continuity bookmark

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68699ff75f68832ebb118c0e2e76ddea