### PR TITLE
Add bookmarks feature and update reading plans

### DIFF
--- a/Models/ReadingPlan.swift
+++ b/Models/ReadingPlan.swift
@@ -3,8 +3,12 @@ import Foundation
 
 struct ReadingPlan: Codable {
     var startDate: Date
-    var chaptersPerWeek: Int
+    var dailyChapters: [String: Int]
     var notificationsEnabled: Bool
+
+    var chaptersPerWeek: Int {
+        dailyChapters.values.reduce(0, +)
+    }
 
     var estimatedCompletion: Date {
         // 1189 chapters in the Bible
@@ -14,17 +18,27 @@ struct ReadingPlan: Codable {
 }
 
 extension ReadingPlan {
+    init(startDate: Date = Date(), dailyChapters: [String: Int] = [:], notificationsEnabled: Bool = false) {
+        self.startDate = startDate
+        self.dailyChapters = dailyChapters
+        self.notificationsEnabled = notificationsEnabled
+    }
+
     init?(dict: [String: Any]) {
         guard let timestamp = dict["startDate"] as? Timestamp else { return nil }
         startDate = timestamp.dateValue()
-        chaptersPerWeek = dict["chaptersPerWeek"] as? Int ?? 1
+        dailyChapters = dict["dailyChapters"] as? [String: Int] ?? [:]
+        if dailyChapters.isEmpty {
+            let perWeek = dict["chaptersPerWeek"] as? Int ?? 1
+            dailyChapters = ["Mon": perWeek]
+        }
         notificationsEnabled = dict["notificationsEnabled"] as? Bool ?? false
     }
 
     var dictionary: [String: Any] {
         [
             "startDate": Timestamp(date: startDate),
-            "chaptersPerWeek": chaptersPerWeek,
+            "dailyChapters": dailyChapters,
             "notificationsEnabled": notificationsEnabled
         ]
     }

--- a/Models/UserProfile.swift
+++ b/Models/UserProfile.swift
@@ -5,20 +5,20 @@ struct UserProfile {
     var chaptersBookmarked: [String: [Int]]
     var lastRead: [String: [String: Int]]
     var readingPlan: ReadingPlan?
-    var continuityBookmark: String?
+    var bookmarks: [String]
     var lastReadBookId: String?
 
     init(chaptersRead: [String: [Int]] = [:],
          chaptersBookmarked: [String: [Int]] = [:],
          lastRead: [String: [String: Int]] = [:],
          readingPlan: ReadingPlan? = nil,
-         continuityBookmark: String? = nil,
+         bookmarks: [String] = [],
          lastReadBookId: String? = nil) {
         self.chaptersRead = chaptersRead
         self.chaptersBookmarked = chaptersBookmarked
         self.lastRead = lastRead
         self.readingPlan = readingPlan
-        self.continuityBookmark = continuityBookmark
+        self.bookmarks = bookmarks
         self.lastReadBookId = lastReadBookId
     }
 }
@@ -32,22 +32,20 @@ extension UserProfile {
         if let planData = dict["readingPlan"] as? [String: Any] {
             plan = ReadingPlan(dict: planData)
         }
-        let bookmark = dict["continuityBookmark"] as? String
+        let bookmarks = dict["bookmarks"] as? [String] ?? []
         let lastBook = dict["lastReadBookId"] as? String
-        self.init(chaptersRead: chaptersRead, chaptersBookmarked: chaptersBookmarked, lastRead: lastRead, readingPlan: plan, continuityBookmark: bookmark, lastReadBookId: lastBook)
+        self.init(chaptersRead: chaptersRead, chaptersBookmarked: chaptersBookmarked, lastRead: lastRead, readingPlan: plan, bookmarks: bookmarks, lastReadBookId: lastBook)
     }
 
     var dictionary: [String: Any] {
         var dict: [String: Any] = [
             "chaptersRead": chaptersRead,
             "chaptersBookmarked": chaptersBookmarked,
-            "lastRead": lastRead
+            "lastRead": lastRead,
+            "bookmarks": bookmarks
         ]
         if let plan = readingPlan {
             dict["readingPlan"] = plan.dictionary
-        }
-        if let bm = continuityBookmark {
-            dict["continuityBookmark"] = bm
         }
         if let lastBook = lastReadBookId {
             dict["lastReadBookId"] = lastBook

--- a/ViewModels/AuthViewModel.swift
+++ b/ViewModels/AuthViewModel.swift
@@ -156,8 +156,21 @@ class AuthViewModel: ObservableObject {
         saveProfile()
     }
 
-    func setContinuityBookmark(bookId: String, chapter: Int, verse: Int) {
-        profile.continuityBookmark = "\(bookId).\(chapter).\(verse)"
-        saveProfile()
+    func addBookmark(_ verseId: String) {
+        if !profile.bookmarks.contains(verseId) {
+            profile.bookmarks.append(verseId)
+            saveProfile()
+        }
+    }
+
+    func removeBookmark(_ verseId: String) {
+        if let idx = profile.bookmarks.firstIndex(of: verseId) {
+            profile.bookmarks.remove(at: idx)
+            saveProfile()
+        }
+    }
+
+    func isBookmarked(_ verseId: String) -> Bool {
+        profile.bookmarks.contains(verseId)
     }
 }

--- a/Views/BookmarksView.swift
+++ b/Views/BookmarksView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+struct BookmarksView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var verses: [Verse] = []
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(verses, id: \.id) { verse in
+                    NavigationLink(destination: ChapterView(chapterId: referencePrefix(for: verse.id), bibleId: defaultBibleId, highlightVerse: Int(verse.verseNumber))) {
+                        VStack(alignment: .leading) {
+                            Text(verse.reference)
+                                .font(.headline)
+                            Text(verse.cleanedText)
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .contextMenu {
+                        Button("Remove") {
+                            authViewModel.removeBookmark(verse.id)
+                            loadVerses()
+                        }
+                    }
+                }
+                .onDelete(perform: delete)
+            }
+            .navigationTitle("Bookmarks")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .onAppear(perform: loadVerses)
+        }
+    }
+
+    private func referencePrefix(for id: String) -> String {
+        let parts = id.split(separator: ".")
+        guard parts.count >= 2 else { return id }
+        return parts[0] + "." + parts[1]
+    }
+
+    private func delete(at offsets: IndexSet) {
+        for index in offsets {
+            authViewModel.removeBookmark(verses[index].id)
+        }
+        loadVerses()
+    }
+
+    private func loadVerses() {
+        verses = []
+        let ids = authViewModel.profile.bookmarks
+        for id in ids {
+            BibleAPI.shared.fetchVerse(reference: id) { result in
+                if case .success(let verse) = result {
+                    DispatchQueue.main.async {
+                        verses.append(verse)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct BookmarksView_Previews: PreviewProvider {
+    static var previews: some View {
+        BookmarksView()
+            .environmentObject(AuthViewModel())
+    }
+}

--- a/Views/ChapterView.swift
+++ b/Views/ChapterView.swift
@@ -17,6 +17,7 @@ struct ChapterView: View {
     @State private var navigateToNext: (bookId: String, chapter: Int)? = nil
     @State private var navigateToBook: BibleBook? = nil
     @StateObject private var searchManager = BibleSearchManager()
+    @State private var showBookmarks = false
 
     // Heading components
     var bookName: String {
@@ -129,8 +130,13 @@ struct ChapterView: View {
                 }
             }
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: backToBooks) {
-                    Image(systemName: "book.closed")
+                HStack {
+                    Button(action: { showBookmarks = true }) {
+                        Image(systemName: "bookmark")
+                    }
+                    Button(action: backToBooks) {
+                        Image(systemName: "book.closed")
+                    }
                 }
             }
         }
@@ -168,6 +174,10 @@ struct ChapterView: View {
                 set: { if !$0 { navigateToBook = nil } }
             )
         ) { EmptyView() }
+
+        .sheet(isPresented: $showBookmarks) {
+            BookmarksView()
+        }
     }
     
     // MARK: - Previous/Next chapter navigation
@@ -286,7 +296,7 @@ struct VerseRowView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
 
     var isBookmarked: Bool {
-        authViewModel.profile.continuityBookmark == verse.id
+        authViewModel.isBookmarked(verse.id)
     }
 
     var body: some View {
@@ -312,12 +322,13 @@ struct VerseRowView: View {
         .cornerRadius(6)
         .animation(.easeInOut(duration: 0.3), value: isHighlighted)
         .contextMenu {
-            Button("Set Continuity Bookmark") {
-                let parts = verse.id.split(separator: ".")
-                if parts.count >= 3,
-                   let chapter = Int(parts[1]),
-                   let verseNum = Int(parts[2]) {
-                    authViewModel.setContinuityBookmark(bookId: String(parts[0]), chapter: chapter, verse: verseNum)
+            if isBookmarked {
+                Button("Remove Bookmark") {
+                    authViewModel.removeBookmark(verse.id)
+                }
+            } else {
+                Button("Add Bookmark") {
+                    authViewModel.addBookmark(verse.id)
                 }
             }
         }

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -26,6 +26,12 @@ struct ContentView: View {
                     Image(systemName: "book.closed")
                     Text("Books")
                 }
+
+                BookmarksView()
+                    .tabItem {
+                        Image(systemName: "bookmark")
+                        Text("Bookmarks")
+                    }
             }
         }
     }

--- a/Views/ExpandedBookView.swift
+++ b/Views/ExpandedBookView.swift
@@ -13,6 +13,7 @@ struct ExpandedBookView: View {
 
     @State private var selectedChapter: (book: BibleBook, chapter: Int, verse: Int?)? = nil
     @State private var selectedBook: BibleBook? = nil
+    @State private var showBookmarks = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -113,10 +114,18 @@ struct ExpandedBookView: View {
                 }
             }
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: backToBooks) {
-                    Image(systemName: "book.closed")
+                HStack {
+                    Button(action: { showBookmarks = true }) {
+                        Image(systemName: "bookmark")
+                    }
+                    Button(action: backToBooks) {
+                        Image(systemName: "book.closed")
+                    }
                 }
             }
+        }
+        .sheet(isPresented: $showBookmarks) {
+            BookmarksView()
         }
     }
 

--- a/Views/OverviewVIew.swift
+++ b/Views/OverviewVIew.swift
@@ -249,6 +249,7 @@ struct OverviewView: View {
     @State private var selectedChapter: (book: BibleBook, chapter: Int, verse: Int?)? = nil
     @State private var selectedExpandedBook: BibleBook? = nil
     @State private var scrollTargetBookId: String? = nil
+    @State private var showBookmarks = false
 
     var body: some View {
         // Map the user profile arrays into sets for quick lookup
@@ -378,6 +379,16 @@ struct OverviewView: View {
         }
         .navigationTitle("Books")
         .navigationBarTitleDisplayMode(.large)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: { showBookmarks = true }) {
+                    Image(systemName: "bookmark")
+                }
+            }
+        }
+        .sheet(isPresented: $showBookmarks) {
+            BookmarksView()
+        }
     }
     
     private func handleSearchResultSelection(_ result: BibleSearchResult) {
@@ -669,7 +680,8 @@ struct CategorySection: View {
                     chaptersBookmarked: chaptersBookmarked[book.id] ?? [],
                     lastRead: lastRead[book.id],
                     onContinue: {
-                        let next = lastRead[book.id]?.chapter ?? 1
+                        let read = chaptersRead[book.id] ?? []
+                        let next = (1...book.chapters).first { !read.contains($0) } ?? book.chapters
                         onSelectChapter(book, next)
                     },
                     onExpandBook: { onExpandBook(book) },

--- a/Views/PlanCreatorView.swift
+++ b/Views/PlanCreatorView.swift
@@ -5,34 +5,47 @@ struct PlanCreatorView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
     @Environment(\.dismiss) private var dismiss
 
-    @State private var chaptersPerWeek: Int = 7
+    @State private var dailyChapters: [String: Int] = [
+        "Mon": 1, "Tue": 1, "Wed": 1, "Thu": 1, "Fri": 1, "Sat": 1, "Sun": 1
+    ]
     @State private var notificationsEnabled: Bool = false
     @State private var startDate: Date = Date()
 
     var estimatedCompletion: Date {
-        let plan = ReadingPlan(startDate: startDate, chaptersPerWeek: chaptersPerWeek, notificationsEnabled: notificationsEnabled)
+        let plan = ReadingPlan(startDate: startDate, dailyChapters: dailyChapters, notificationsEnabled: notificationsEnabled)
         return plan.estimatedCompletion
     }
 
     var body: some View {
-        Form {
-            Section(header: Text("Reading Pace")) {
-                Stepper(value: $chaptersPerWeek, in: 1...50) {
-                    Text("Chapters per week: \(chaptersPerWeek)")
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                VStack(alignment: .leading) {
+                    Text("Weekly Schedule")
+                        .font(.title2).bold()
+                    ForEach(["Mon","Tue","Wed","Thu","Fri","Sat","Sun"], id: \.self) { day in
+                        Stepper(value: Binding(get: { dailyChapters[day] ?? 0 }, set: { dailyChapters[day] = $0 }), in: 0...10) {
+                            Text("\(day): \(dailyChapters[day] ?? 0) chapters")
+                        }
+                    }
                 }
-                DatePicker("Start Date", selection: $startDate, displayedComponents: .date)
-                Toggle("Enable Notifications", isOn: $notificationsEnabled)
-            }
 
-            Section(header: Text("Estimate")) {
-                Text("Estimated completion: \(estimatedCompletion, style: .date)")
+                DatePicker("Start Date", selection: $startDate, displayedComponents: .date)
+
+                Toggle("Enable Notifications", isOn: $notificationsEnabled)
+
+                VStack(alignment: .leading) {
+                    Text("Estimated completion")
+                        .font(.headline)
+                    Text(estimatedCompletion, style: .date)
+                }
             }
+            .padding()
         }
         .navigationTitle("Create Plan")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button("Save") {
-                    let plan = ReadingPlan(startDate: startDate, chaptersPerWeek: chaptersPerWeek, notificationsEnabled: notificationsEnabled)
+                    let plan = ReadingPlan(startDate: startDate, dailyChapters: dailyChapters, notificationsEnabled: notificationsEnabled)
                     authViewModel.setReadingPlan(plan)
                     dismiss()
                 }


### PR DESCRIPTION
## Summary
- remove continuity bookmark field
- implement personal bookmarks system with modal and tab
- display bookmark buttons in Books screens
- compute next unread chapter for continue buttons
- redesign plan creator with weekly schedule
- improve Home dashboard

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6869a26dc204832e9d928df033f9f972