### PR TITLE
Fix crash when opening Bookmarks tab

### DIFF
--- a/Views/BookmarksView.swift
+++ b/Views/BookmarksView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct BookmarksView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
+    @EnvironmentObject var booksNav: BooksNavigationManager
     @Environment(\.dismiss) private var dismiss
 
     @State private var verses: [Verse] = []
@@ -70,5 +71,6 @@ struct BookmarksView_Previews: PreviewProvider {
     static var previews: some View {
         BookmarksView()
             .environmentObject(AuthViewModel())
+            .environmentObject(BooksNavigationManager())
     }
 }

--- a/Views/ChapterView.swift
+++ b/Views/ChapterView.swift
@@ -177,6 +177,7 @@ struct ChapterView: View {
 
         .sheet(isPresented: $showBookmarks) {
             BookmarksView()
+                .environmentObject(booksNav)
         }
     }
     

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -28,6 +28,7 @@ struct ContentView: View {
                 }
 
                 BookmarksView()
+                    .environmentObject(booksNavigationManager)
                     .tabItem {
                         Image(systemName: "bookmark")
                         Text("Bookmarks")

--- a/Views/ExpandedBookView.swift
+++ b/Views/ExpandedBookView.swift
@@ -126,6 +126,7 @@ struct ExpandedBookView: View {
         }
         .sheet(isPresented: $showBookmarks) {
             BookmarksView()
+                .environmentObject(booksNav)
         }
     }
 

--- a/Views/OverviewVIew.swift
+++ b/Views/OverviewVIew.swift
@@ -246,6 +246,7 @@ struct OverviewView: View {
     @StateObject private var searchManager = BibleSearchManager()
     @State private var expandedBookId: String? = nil
     @EnvironmentObject var authViewModel: AuthViewModel
+    @EnvironmentObject var booksNav: BooksNavigationManager
     @State private var selectedChapter: (book: BibleBook, chapter: Int, verse: Int?)? = nil
     @State private var selectedExpandedBook: BibleBook? = nil
     @State private var scrollTargetBookId: String? = nil
@@ -388,6 +389,7 @@ struct OverviewView: View {
         }
         .sheet(isPresented: $showBookmarks) {
             BookmarksView()
+                .environmentObject(booksNav)
         }
     }
     


### PR DESCRIPTION
## Summary
- add `BooksNavigationManager` to `BookmarksView`
- pass navigation manager into `BookmarksView` wherever it's used
- update preview to include the navigation manager

## Testing
- `swiftc Views/ContentView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6869ab7a0ab8832ea9de63df30953a45