### PR TITLE
Add flexible reading plan system

### DIFF
--- a/Models/ReadingPlan.swift
+++ b/Models/ReadingPlan.swift
@@ -1,18 +1,63 @@
 import FirebaseFirestore
 import Foundation
 
+/// Type of goal the reading plan is based on.
+enum ReadingPlanGoalType: String, Codable {
+    case finishByDate
+    case chaptersPerDay
+    case flexible
+}
+
+/// A more flexible reading plan model. It supports "finish by date" or
+/// "chapters per day" styles as well as custom reading days and other
+/// preferences. This is only a starting point and does not yet implement a
+/// full scheduling engine.
 struct ReadingPlan: Codable {
+    var id: String = UUID().uuidString
+    var name: String = "Reading Plan"
+    var colorHex: String? = nil
+
+    /// When the plan begins
     var startDate: Date = Date()
-    var dailyChapters: [String: Int] = [:]
+
+    /// If `goalType` is `.finishByDate` this value represents the desired end
+    /// date. If `.chaptersPerDay` it is ignored.
+    var finishBy: Date? = nil
+
+    /// If `goalType` is `.chaptersPerDay` this is the number of chapters to read
+    /// each reading day.
+    var chaptersPerDay: Int? = nil
+
+    /// Which days of the week the user intends to read. Values use three letter
+    /// abbreviations ("Mon", "Tue", etc.).
+    var readingDays: [String] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+    /// Whether the plan uses a sequential order or allows non-linear reading.
+    var allowNonLinear: Bool = false
+
+    /// Notifications/encouragements enabled
     var notificationsEnabled: Bool = false
 
-    var chaptersPerWeek: Int {
-        dailyChapters.values.reduce(0, +)
-    }
+    /// How the goal is interpreted
+    var goalType: ReadingPlanGoalType = .chaptersPerDay
 
+    /// Estimated completion based on the goal settings. For finish-by-date
+    /// plans this simply returns `finishBy`. For chapter based plans the total
+    /// number of Bible chapters (1189) is used with the per-day amount and
+    /// reading days to estimate a completion date.
     var estimatedCompletion: Date {
-        let weeks = Double(1189) / Double(max(chaptersPerWeek, 1))
-        return Calendar.current.date(byAdding: .day, value: Int(weeks * 7), to: startDate) ?? startDate
+        switch goalType {
+        case .finishByDate:
+            return finishBy ?? startDate
+        case .chaptersPerDay:
+            let daily = Double(chaptersPerDay ?? 1)
+            let daysPerWeek = max(Double(readingDays.count), 1)
+            let perWeek = daily * daysPerWeek
+            let weeks = ceil(Double(1189) / max(perWeek, 1))
+            return Calendar.current.date(byAdding: .day, value: Int(weeks * 7), to: startDate) ?? startDate
+        case .flexible:
+            return startDate
+        }
     }
 }
 
@@ -20,20 +65,31 @@ extension ReadingPlan {
     init?(dict: [String: Any]) {
         guard let timestamp = dict["startDate"] as? Timestamp else { return nil }
         startDate = timestamp.dateValue()
-        dailyChapters = dict["dailyChapters"] as? [String: Int] ?? [:]
-        if dailyChapters.isEmpty {
-            let perWeek = dict["chaptersPerWeek"] as? Int ?? 1
-            dailyChapters = ["Mon": perWeek]
-        }
+        name = dict["name"] as? String ?? "Reading Plan"
+        colorHex = dict["colorHex"] as? String
+        id = dict["id"] as? String ?? UUID().uuidString
+        if let finish = dict["finishBy"] as? Timestamp { finishBy = finish.dateValue() }
+        chaptersPerDay = dict["chaptersPerDay"] as? Int
+        readingDays = dict["readingDays"] as? [String] ?? ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"]
+        allowNonLinear = dict["allowNonLinear"] as? Bool ?? false
         notificationsEnabled = dict["notificationsEnabled"] as? Bool ?? false
+        goalType = ReadingPlanGoalType(rawValue: dict["goalType"] as? String ?? "chaptersPerDay") ?? .chaptersPerDay
     }
 
     var dictionary: [String: Any] {
-        [
+        var dict: [String: Any] = [
+            "id": id,
+            "name": name,
             "startDate": Timestamp(date: startDate),
-            "dailyChapters": dailyChapters,
-            "notificationsEnabled": notificationsEnabled
+            "readingDays": readingDays,
+            "allowNonLinear": allowNonLinear,
+            "notificationsEnabled": notificationsEnabled,
+            "goalType": goalType.rawValue
         ]
+        if let color = colorHex { dict["colorHex"] = color }
+        if let finish = finishBy { dict["finishBy"] = Timestamp(date: finish) }
+        if let perDay = chaptersPerDay { dict["chaptersPerDay"] = perDay }
+        return dict
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ attempt again.
   - Selecting a book result opens an expanded view listing all chapters in a grid
   - Book scrolling uses async repeated attempts to reliably center the selected book
   - Each book dropdown offers an "Expand Book" button for quick access to the grid view
+ - Flexible reading plans with support for finish-by-date or chapters-per-day goals

--- a/Views/HomeView.swift
+++ b/Views/HomeView.swift
@@ -11,8 +11,24 @@ struct HomeView: View {
                 VStack(alignment: .leading, spacing: 24) {
                     if let plan = authViewModel.profile.readingPlan {
                         VStack(alignment: .leading, spacing: 8) {
-                            Text("Weekly Goal: \(plan.chaptersPerWeek) chapters")
+                            Text(plan.name)
                                 .font(.title3).bold()
+
+                            switch plan.goalType {
+                            case .chaptersPerDay:
+                                let amount = plan.chaptersPerDay ?? 1
+                                Text("Goal: \(amount) chapters per day")
+                                    .font(.subheadline)
+                            case .finishByDate:
+                                if let end = plan.finishBy {
+                                    Text("Finish by \(end, style: .date)")
+                                        .font(.subheadline)
+                                }
+                            case .flexible:
+                                Text("Flexible pace")
+                                    .font(.subheadline)
+                            }
+
                             ProgressView(value: Double(authViewModel.profile.totalChaptersRead), total: 1189)
                                 .accentColor(.green)
                             Text("Estimated completion: \(plan.estimatedCompletion, style: .date)")

--- a/Views/PlanCreatorView.swift
+++ b/Views/PlanCreatorView.swift
@@ -1,36 +1,78 @@
 import FirebaseFirestore
 import SwiftUI
 
+/// Simple creator UI for the new flexible ``ReadingPlan`` model. It only
+/// covers a subset of all options but demonstrates how a user can configure
+/// a goal and schedule.
 struct PlanCreatorView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
     @Environment(\.dismiss) private var dismiss
 
-    @State private var dailyChapters: [String: Int] = [
-        "Mon": 1, "Tue": 1, "Wed": 1, "Thu": 1, "Fri": 1, "Sat": 1, "Sun": 1
-    ]
-    @State private var notificationsEnabled: Bool = false
+    @State private var name: String = "My Plan"
+    @State private var goalType: ReadingPlanGoalType = .chaptersPerDay
+    @State private var chaptersPerDay: Int = 1
+    @State private var finishBy: Date = Calendar.current.date(byAdding: .month, value: 3, to: Date()) ?? Date()
     @State private var startDate: Date = Date()
+    @State private var notificationsEnabled: Bool = false
+    @State private var readingDays: Set<String> = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+    @State private var allowNonLinear: Bool = false
+
+    private let allDays = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"]
 
     var estimatedCompletion: Date {
-        let plan = ReadingPlan(startDate: startDate, dailyChapters: dailyChapters, notificationsEnabled: notificationsEnabled)
+        let plan = ReadingPlan(
+            name: name,
+            startDate: startDate,
+            finishBy: goalType == .finishByDate ? finishBy : nil,
+            chaptersPerDay: goalType == .chaptersPerDay ? chaptersPerDay : nil,
+            readingDays: Array(readingDays),
+            allowNonLinear: allowNonLinear,
+            notificationsEnabled: notificationsEnabled,
+            goalType: goalType
+        )
         return plan.estimatedCompletion
     }
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
+                TextField("Plan Name", text: $name)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+
+                Picker("Goal", selection: $goalType) {
+                    Text("Chapters/Day").tag(ReadingPlanGoalType.chaptersPerDay)
+                    Text("Finish By Date").tag(ReadingPlanGoalType.finishByDate)
+                }
+                .pickerStyle(SegmentedPickerStyle())
+
+                if goalType == .chaptersPerDay {
+                    Stepper(value: $chaptersPerDay, in: 1...10) {
+                        Text("\(chaptersPerDay) chapters per day")
+                    }
+                } else if goalType == .finishByDate {
+                    DatePicker("Finish By", selection: $finishBy, displayedComponents: .date)
+                }
+
                 VStack(alignment: .leading) {
-                    Text("Weekly Schedule")
-                        .font(.title2).bold()
-                    ForEach(["Mon","Tue","Wed","Thu","Fri","Sat","Sun"], id: \.self) { day in
-                        Stepper(value: Binding(get: { dailyChapters[day] ?? 0 }, set: { dailyChapters[day] = $0 }), in: 0...10) {
-                            Text("\(day): \(dailyChapters[day] ?? 0) chapters")
+                    Text("Reading Days")
+                        .font(.headline)
+                    HStack {
+                        ForEach(allDays, id: \.self) { day in
+                            Button(action: {
+                                if readingDays.contains(day) { readingDays.remove(day) } else { readingDays.insert(day) }
+                            }) {
+                                Text(day)
+                                    .padding(6)
+                                    .background(readingDays.contains(day) ? Color.blue : Color.gray.opacity(0.3))
+                                    .foregroundColor(.white)
+                                    .cornerRadius(6)
+                            }
                         }
                     }
                 }
 
+                Toggle("Allow Non-Linear Reading", isOn: $allowNonLinear)
                 DatePicker("Start Date", selection: $startDate, displayedComponents: .date)
-
                 Toggle("Enable Notifications", isOn: $notificationsEnabled)
 
                 VStack(alignment: .leading) {
@@ -45,7 +87,16 @@ struct PlanCreatorView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button("Save") {
-                    let plan = ReadingPlan(startDate: startDate, dailyChapters: dailyChapters, notificationsEnabled: notificationsEnabled)
+                    let plan = ReadingPlan(
+                        name: name,
+                        startDate: startDate,
+                        finishBy: goalType == .finishByDate ? finishBy : nil,
+                        chaptersPerDay: goalType == .chaptersPerDay ? chaptersPerDay : nil,
+                        readingDays: Array(readingDays),
+                        allowNonLinear: allowNonLinear,
+                        notificationsEnabled: notificationsEnabled,
+                        goalType: goalType
+                    )
                     authViewModel.setReadingPlan(plan)
                     dismiss()
                 }


### PR DESCRIPTION
## Summary
- redesign `ReadingPlan` to support finish-by-date or chapters-per-day goals
- update plan creator UI with new options like reading days and non-linear reading
- adapt home view display for the new plan model
- document flexible reading plans in README

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6869b3e502ac832eb75cf7b10397f638