### PR TITLE
Enable editing of reading plans

### DIFF
--- a/Models/ReadingPlan.swift
+++ b/Models/ReadingPlan.swift
@@ -1,18 +1,63 @@
 import FirebaseFirestore
 import Foundation
 
-struct ReadingPlan: Codable {
+/// Type of goal the reading plan is based on.
+enum ReadingPlanGoalType: String, Codable {
+    case finishByDate
+    case chaptersPerDay
+    case flexible
+}
+
+/// A more flexible reading plan model. It supports "finish by date" or
+/// "chapters per day" styles as well as custom reading days and other
+/// preferences. This is only a starting point and does not yet implement a
+/// full scheduling engine.
+struct ReadingPlan: Codable, Identifiable {
+    var id: String = UUID().uuidString
+    var name: String = "Reading Plan"
+    var colorHex: String? = nil
+
+    /// When the plan begins
     var startDate: Date = Date()
-    var dailyChapters: [String: Int] = [:]
+
+    /// If `goalType` is `.finishByDate` this value represents the desired end
+    /// date. If `.chaptersPerDay` it is ignored.
+    var finishBy: Date? = nil
+
+    /// If `goalType` is `.chaptersPerDay` this is the number of chapters to read
+    /// each reading day.
+    var chaptersPerDay: Int? = nil
+
+    /// Which days of the week the user intends to read. Values use three letter
+    /// abbreviations ("Mon", "Tue", etc.).
+    var readingDays: [String] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+    /// Whether the plan uses a sequential order or allows non-linear reading.
+    var allowNonLinear: Bool = false
+
+    /// Notifications/encouragements enabled
     var notificationsEnabled: Bool = false
 
-    var chaptersPerWeek: Int {
-        dailyChapters.values.reduce(0, +)
-    }
+    /// How the goal is interpreted
+    var goalType: ReadingPlanGoalType = .chaptersPerDay
 
+    /// Estimated completion based on the goal settings. For finish-by-date
+    /// plans this simply returns `finishBy`. For chapter based plans the total
+    /// number of Bible chapters (1189) is used with the per-day amount and
+    /// reading days to estimate a completion date.
     var estimatedCompletion: Date {
-        let weeks = Double(1189) / Double(max(chaptersPerWeek, 1))
-        return Calendar.current.date(byAdding: .day, value: Int(weeks * 7), to: startDate) ?? startDate
+        switch goalType {
+        case .finishByDate:
+            return finishBy ?? startDate
+        case .chaptersPerDay:
+            let daily = Double(chaptersPerDay ?? 1)
+            let daysPerWeek = max(Double(readingDays.count), 1)
+            let perWeek = daily * daysPerWeek
+            let weeks = ceil(Double(1189) / max(perWeek, 1))
+            return Calendar.current.date(byAdding: .day, value: Int(weeks * 7), to: startDate) ?? startDate
+        case .flexible:
+            return startDate
+        }
     }
 }
 
@@ -20,20 +65,31 @@ extension ReadingPlan {
     init?(dict: [String: Any]) {
         guard let timestamp = dict["startDate"] as? Timestamp else { return nil }
         startDate = timestamp.dateValue()
-        dailyChapters = dict["dailyChapters"] as? [String: Int] ?? [:]
-        if dailyChapters.isEmpty {
-            let perWeek = dict["chaptersPerWeek"] as? Int ?? 1
-            dailyChapters = ["Mon": perWeek]
-        }
+        name = dict["name"] as? String ?? "Reading Plan"
+        colorHex = dict["colorHex"] as? String
+        id = dict["id"] as? String ?? UUID().uuidString
+        if let finish = dict["finishBy"] as? Timestamp { finishBy = finish.dateValue() }
+        chaptersPerDay = dict["chaptersPerDay"] as? Int
+        readingDays = dict["readingDays"] as? [String] ?? ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"]
+        allowNonLinear = dict["allowNonLinear"] as? Bool ?? false
         notificationsEnabled = dict["notificationsEnabled"] as? Bool ?? false
+        goalType = ReadingPlanGoalType(rawValue: dict["goalType"] as? String ?? "chaptersPerDay") ?? .chaptersPerDay
     }
 
     var dictionary: [String: Any] {
-        [
+        var dict: [String: Any] = [
+            "id": id,
+            "name": name,
             "startDate": Timestamp(date: startDate),
-            "dailyChapters": dailyChapters,
-            "notificationsEnabled": notificationsEnabled
+            "readingDays": readingDays,
+            "allowNonLinear": allowNonLinear,
+            "notificationsEnabled": notificationsEnabled,
+            "goalType": goalType.rawValue
         ]
+        if let color = colorHex { dict["colorHex"] = color }
+        if let finish = finishBy { dict["finishBy"] = Timestamp(date: finish) }
+        if let perDay = chaptersPerDay { dict["chaptersPerDay"] = perDay }
+        return dict
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ attempt again.
   - Selecting a book result opens an expanded view listing all chapters in a grid
   - Book scrolling uses async repeated attempts to reliably center the selected book
   - Each book dropdown offers an "Expand Book" button for quick access to the grid view
+- Flexible reading plans with support for finish-by-date or chapters-per-day goals
+- Edit your reading plan anytime from the Home tab

--- a/ViewModels/AuthViewModel.swift
+++ b/ViewModels/AuthViewModel.swift
@@ -156,6 +156,12 @@ class AuthViewModel: ObservableObject {
         saveProfile()
     }
 
+    /// Remove the user's reading plan entirely.
+    func deleteReadingPlan() {
+        profile.readingPlan = nil
+        saveProfile()
+    }
+
     func addBookmark(_ verseId: String) {
         if !profile.bookmarks.contains(verseId) {
             profile.bookmarks.append(verseId)

--- a/Views/HomeView.swift
+++ b/Views/HomeView.swift
@@ -4,6 +4,7 @@ struct HomeView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
 
     @State private var showPlanCreator = false
+    @State private var editingPlan: ReadingPlan? = nil
 
     var body: some View {
         NavigationView {
@@ -11,13 +12,35 @@ struct HomeView: View {
                 VStack(alignment: .leading, spacing: 24) {
                     if let plan = authViewModel.profile.readingPlan {
                         VStack(alignment: .leading, spacing: 8) {
-                            Text("Weekly Goal: \(plan.chaptersPerWeek) chapters")
+                            Text(plan.name)
                                 .font(.title3).bold()
-                            ProgressView(value: Double(authViewModel.profile.totalChaptersRead), total: 1189)
-                                .accentColor(.green)
-                            Text("Estimated completion: \(plan.estimatedCompletion, style: .date)")
-                                .font(.footnote)
+
+                            switch plan.goalType {
+                            case .chaptersPerDay:
+                                let amount = plan.chaptersPerDay ?? 1
+                                Text("Goal: \(amount) chapters per day")
+                                    .font(.subheadline)
+                            case .finishByDate:
+                                if let end = plan.finishBy {
+                                    Text("Finish by \(end, style: .date)")
+                                        .font(.subheadline)
+                                }
+                            case .flexible:
+                                Text("Flexible pace")
+                                    .font(.subheadline)
+                            }
+
+                        ProgressView(value: Double(authViewModel.profile.totalChaptersRead), total: 1189)
+                            .accentColor(.green)
+                        Text("Estimated completion: \(plan.estimatedCompletion, style: .date)")
+                            .font(.footnote)
+                        Button("Edit Plan") {
+                            editingPlan = plan
                         }
+                        .font(.subheadline)
+                        .foregroundColor(.blue)
+                        .padding(.top, 4)
+                    }
 
                         if let last = lastReadReference() {
                             NavigationLink(destination: ChapterView(chapterId: last.ref, bibleId: defaultBibleId, highlightVerse: last.verse)) {
@@ -47,6 +70,9 @@ struct HomeView: View {
             .navigationTitle("Home")
             .sheet(isPresented: $showPlanCreator) {
                 NavigationView { PlanCreatorView() }
+            }
+            .sheet(item: $editingPlan) { plan in
+                NavigationView { PlanCreatorView(existingPlan: plan) }
             }
         }
     }

--- a/Views/PlanCreatorView.swift
+++ b/Views/PlanCreatorView.swift
@@ -1,36 +1,93 @@
 import FirebaseFirestore
 import SwiftUI
 
+/// Simple creator UI for the new flexible ``ReadingPlan`` model. It only
+/// covers a subset of all options but demonstrates how a user can configure
+/// a goal and schedule.
 struct PlanCreatorView: View {
+    /// If non-nil the view edits an existing plan instead of creating a new one.
+    var existingPlan: ReadingPlan?
+
     @EnvironmentObject var authViewModel: AuthViewModel
     @Environment(\.dismiss) private var dismiss
 
-    @State private var dailyChapters: [String: Int] = [
-        "Mon": 1, "Tue": 1, "Wed": 1, "Thu": 1, "Fri": 1, "Sat": 1, "Sun": 1
-    ]
-    @State private var notificationsEnabled: Bool = false
+    @State private var name: String = "My Plan"
+    @State private var goalType: ReadingPlanGoalType = .chaptersPerDay
+    @State private var chaptersPerDay: Int = 1
+    @State private var finishBy: Date = Calendar.current.date(byAdding: .month, value: 3, to: Date()) ?? Date()
     @State private var startDate: Date = Date()
+    @State private var notificationsEnabled: Bool = false
+    @State private var readingDays: Set<String> = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+    @State private var allowNonLinear: Bool = false
+
+    init(existingPlan: ReadingPlan? = nil) {
+        self.existingPlan = existingPlan
+        _name = State(initialValue: existingPlan?.name ?? "My Plan")
+        _goalType = State(initialValue: existingPlan?.goalType ?? .chaptersPerDay)
+        _chaptersPerDay = State(initialValue: existingPlan?.chaptersPerDay ?? 1)
+        _finishBy = State(initialValue: existingPlan?.finishBy ?? Calendar.current.date(byAdding: .month, value: 3, to: Date()) ?? Date())
+        _startDate = State(initialValue: existingPlan?.startDate ?? Date())
+        _notificationsEnabled = State(initialValue: existingPlan?.notificationsEnabled ?? false)
+        _readingDays = State(initialValue: Set(existingPlan?.readingDays ?? ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"]))
+        _allowNonLinear = State(initialValue: existingPlan?.allowNonLinear ?? false)
+    }
+
+    private let allDays = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"]
 
     var estimatedCompletion: Date {
-        let plan = ReadingPlan(startDate: startDate, dailyChapters: dailyChapters, notificationsEnabled: notificationsEnabled)
+        let plan = ReadingPlan(
+            name: name,
+            startDate: startDate,
+            finishBy: goalType == .finishByDate ? finishBy : nil,
+            chaptersPerDay: goalType == .chaptersPerDay ? chaptersPerDay : nil,
+            readingDays: Array(readingDays),
+            allowNonLinear: allowNonLinear,
+            notificationsEnabled: notificationsEnabled,
+            goalType: goalType
+        )
         return plan.estimatedCompletion
     }
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
+                TextField("Plan Name", text: $name)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+
+                Picker("Goal", selection: $goalType) {
+                    Text("Chapters/Day").tag(ReadingPlanGoalType.chaptersPerDay)
+                    Text("Finish By Date").tag(ReadingPlanGoalType.finishByDate)
+                }
+                .pickerStyle(SegmentedPickerStyle())
+
+                if goalType == .chaptersPerDay {
+                    Stepper(value: $chaptersPerDay, in: 1...10) {
+                        Text("\(chaptersPerDay) chapters per day")
+                    }
+                } else if goalType == .finishByDate {
+                    DatePicker("Finish By", selection: $finishBy, displayedComponents: .date)
+                }
+
                 VStack(alignment: .leading) {
-                    Text("Weekly Schedule")
-                        .font(.title2).bold()
-                    ForEach(["Mon","Tue","Wed","Thu","Fri","Sat","Sun"], id: \.self) { day in
-                        Stepper(value: Binding(get: { dailyChapters[day] ?? 0 }, set: { dailyChapters[day] = $0 }), in: 0...10) {
-                            Text("\(day): \(dailyChapters[day] ?? 0) chapters")
+                    Text("Reading Days")
+                        .font(.headline)
+                    HStack {
+                        ForEach(allDays, id: \.self) { day in
+                            Button(action: {
+                                if readingDays.contains(day) { readingDays.remove(day) } else { readingDays.insert(day) }
+                            }) {
+                                Text(day)
+                                    .padding(6)
+                                    .background(readingDays.contains(day) ? Color.blue : Color.gray.opacity(0.3))
+                                    .foregroundColor(.white)
+                                    .cornerRadius(6)
+                            }
                         }
                     }
                 }
 
+                Toggle("Allow Non-Linear Reading", isOn: $allowNonLinear)
                 DatePicker("Start Date", selection: $startDate, displayedComponents: .date)
-
                 Toggle("Enable Notifications", isOn: $notificationsEnabled)
 
                 VStack(alignment: .leading) {
@@ -41,13 +98,32 @@ struct PlanCreatorView: View {
             }
             .padding()
         }
-        .navigationTitle("Create Plan")
+        .navigationTitle(existingPlan == nil ? "Create Plan" : "Edit Plan")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button("Save") {
-                    let plan = ReadingPlan(startDate: startDate, dailyChapters: dailyChapters, notificationsEnabled: notificationsEnabled)
+                    let plan = ReadingPlan(
+                        name: name,
+                        startDate: startDate,
+                        finishBy: goalType == .finishByDate ? finishBy : nil,
+                        chaptersPerDay: goalType == .chaptersPerDay ? chaptersPerDay : nil,
+                        readingDays: Array(readingDays),
+                        allowNonLinear: allowNonLinear,
+                        notificationsEnabled: notificationsEnabled,
+                        goalType: goalType
+                    )
                     authViewModel.setReadingPlan(plan)
                     dismiss()
+                }
+            }
+            if existingPlan != nil {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(role: .destructive) {
+                        authViewModel.deleteReadingPlan()
+                        dismiss()
+                    } label: {
+                        Text("Delete")
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- mark `ReadingPlan` as `Identifiable`
- allow editing and deletion through `PlanCreatorView`
- expose `Edit Plan` button on home screen
- add `deleteReadingPlan` helper in `AuthViewModel`
- document editing in README

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6869b3e502ac832eb75cf7b10397f638