### PR TITLE
Add reading plan presets and progress tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,6 @@ attempt again.
   - Book scrolling uses async repeated attempts to reliably center the selected book
   - Each book dropdown offers an "Expand Book" button for quick access to the grid view
 - Flexible reading plans with support for finish-by-date or chapters-per-day goals
+- Reading plans are non-linear by default and can be built from presets such as the full Bible, Old or New Testament, Gospels, Prophets, and more
+- Each plan stores a progress tree so completion can be computed from your reading history
 - Edit your reading plan anytime from the Home tab

--- a/Views/PlanCreatorView.swift
+++ b/Views/PlanCreatorView.swift
@@ -18,7 +18,8 @@ struct PlanCreatorView: View {
     @State private var startDate: Date = Date()
     @State private var notificationsEnabled: Bool = false
     @State private var readingDays: Set<String> = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
-    @State private var allowNonLinear: Bool = false
+    @State private var allowNonLinear: Bool = true
+    @State private var preset: ReadingPlanPreset = .fullBible
 
     init(existingPlan: ReadingPlan? = nil) {
         self.existingPlan = existingPlan
@@ -29,7 +30,8 @@ struct PlanCreatorView: View {
         _startDate = State(initialValue: existingPlan?.startDate ?? Date())
         _notificationsEnabled = State(initialValue: existingPlan?.notificationsEnabled ?? false)
         _readingDays = State(initialValue: Set(existingPlan?.readingDays ?? ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"]))
-        _allowNonLinear = State(initialValue: existingPlan?.allowNonLinear ?? false)
+        _allowNonLinear = State(initialValue: existingPlan?.allowNonLinear ?? true)
+        _preset = State(initialValue: existingPlan?.preset ?? .fullBible)
     }
     private let allDays = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"]
 
@@ -42,7 +44,9 @@ struct PlanCreatorView: View {
             readingDays: Array(readingDays),
             allowNonLinear: allowNonLinear,
             notificationsEnabled: notificationsEnabled,
-            goalType: goalType
+            goalType: goalType,
+            preset: preset,
+            nodes: []
         )
         return plan.estimatedCompletion
     }
@@ -52,6 +56,12 @@ struct PlanCreatorView: View {
             VStack(alignment: .leading, spacing: 20) {
                 TextField("Plan Name", text: $name)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
+
+                Picker("Plan Preset", selection: $preset) {
+                    ForEach(ReadingPlanPreset.allCases, id: \.self) { p in
+                        Text(String(describing: p).capitalized).tag(p)
+                    }
+                }
 
                 Picker("Goal", selection: $goalType) {
                     Text("Chapters/Day").tag(ReadingPlanGoalType.chaptersPerDay)
@@ -85,7 +95,6 @@ struct PlanCreatorView: View {
                     }
                 }
 
-                Toggle("Allow Non-Linear Reading", isOn: $allowNonLinear)
                 DatePicker("Start Date", selection: $startDate, displayedComponents: .date)
                 Toggle("Enable Notifications", isOn: $notificationsEnabled)
 
@@ -109,7 +118,9 @@ struct PlanCreatorView: View {
                         readingDays: Array(readingDays),
                         allowNonLinear: allowNonLinear,
                         notificationsEnabled: notificationsEnabled,
-                        goalType: goalType
+                        goalType: goalType,
+                        preset: preset,
+                        nodes: []
                     )
                     authViewModel.setReadingPlan(plan)
                     dismiss()


### PR DESCRIPTION
## Summary
- add new `ReadingPlanPreset` enum and `ReadingPlanNode` tree model
- default plans are non-linear and keep progress nodes
- allow choosing a preset when creating a plan
- update README with new plan features

## Testing
- `swiftc -parse Views/PlanCreatorView.swift Models/ReadingPlan.swift Models/UserProfile.swift`
- `find . -name '*.swift' | xargs swiftc -parse`

------
https://chatgpt.com/codex/tasks/task_e_6869b9404434832eac64180c2a9991c3