### PR TITLE
Add customizable chapters and notification times

### DIFF
--- a/Views/HomeView.swift
+++ b/Views/HomeView.swift
@@ -17,9 +17,14 @@ struct HomeView: View {
 
                             switch plan.goalType {
                             case .chaptersPerDay:
-                                let amount = plan.chaptersPerDay ?? 1
-                                Text("Goal: \(amount) chapters per day")
-                                    .font(.subheadline)
+                                if let custom = plan.chaptersPerDayByDay {
+                                    Text("Goal: variable chapters per day")
+                                        .font(.subheadline)
+                                } else {
+                                    let amount = plan.chaptersPerDay ?? 1
+                                    Text("Goal: \(amount) chapters per day")
+                                        .font(.subheadline)
+                                }
                             case .finishByDate:
                                 if let end = plan.finishBy {
                                     Text("Finish by \(end, style: .date)")


### PR DESCRIPTION
## Summary
- extend `ReadingPlan` model to support per-day chapter counts and notification times
- allow customizing chapter amounts and notification times in `PlanCreatorView`
- update home screen to display variable chapter goals
- style `PlanCreatorView` with a background gradient

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6869bbde4e18832e9d72bb3e10fb4d8c