### PR TITLE
Add daily progress circle

### DIFF
--- a/DateExtensions.swift
+++ b/DateExtensions.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension Date {
+    /// e.g. "2024-07-06"
+    var isoDateString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = TimeZone.current
+        return formatter.string(from: self)
+    }
+    /// e.g. "Mon" "Tue"
+    var weekdayAbbrev: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEE"
+        formatter.timeZone = TimeZone.current
+        return formatter.string(from: self)
+    }
+}

--- a/Models/ReadingPlan.swift
+++ b/Models/ReadingPlan.swift
@@ -192,5 +192,15 @@ extension ReadingPlan {
         if let times = notificationTimesByDay { dict["notificationTimesByDay"] = times }
         return dict
     }
+
+    /// Chapters expected to be read on the given date.
+    func chaptersForDate(_ date: Date) -> Int {
+        let day = date.weekdayAbbrev
+        guard readingDays.contains(day) else { return 0 }
+        if let custom = chaptersPerDayByDay?[day] {
+            return custom
+        }
+        return chaptersPerDay ?? 1
+    }
 }
 

--- a/Models/UserProfile.swift
+++ b/Models/UserProfile.swift
@@ -7,19 +7,23 @@ struct UserProfile {
     var readingPlan: ReadingPlan?
     var bookmarks: [String]
     var lastReadBookId: String?
+    /// Map of ISO date strings (YYYY-MM-DD) to count of chapters read that day
+    var dailyChapterCounts: [String: Int]
 
     init(chaptersRead: [String: [Int]] = [:],
          chaptersBookmarked: [String: [Int]] = [:],
          lastRead: [String: [String: Int]] = [:],
          readingPlan: ReadingPlan? = nil,
          bookmarks: [String] = [],
-         lastReadBookId: String? = nil) {
+         lastReadBookId: String? = nil,
+         dailyChapterCounts: [String: Int] = [:]) {
         self.chaptersRead = chaptersRead
         self.chaptersBookmarked = chaptersBookmarked
         self.lastRead = lastRead
         self.readingPlan = readingPlan
         self.bookmarks = bookmarks
         self.lastReadBookId = lastReadBookId
+        self.dailyChapterCounts = dailyChapterCounts
     }
 }
 
@@ -34,7 +38,8 @@ extension UserProfile {
         }
         let bookmarks = dict["bookmarks"] as? [String] ?? []
         let lastBook = dict["lastReadBookId"] as? String
-        self.init(chaptersRead: chaptersRead, chaptersBookmarked: chaptersBookmarked, lastRead: lastRead, readingPlan: plan, bookmarks: bookmarks, lastReadBookId: lastBook)
+        let dailyCounts = dict["dailyChapterCounts"] as? [String: Int] ?? [:]
+        self.init(chaptersRead: chaptersRead, chaptersBookmarked: chaptersBookmarked, lastRead: lastRead, readingPlan: plan, bookmarks: bookmarks, lastReadBookId: lastBook, dailyChapterCounts: dailyCounts)
     }
 
     var dictionary: [String: Any] {
@@ -42,7 +47,8 @@ extension UserProfile {
             "chaptersRead": chaptersRead,
             "chaptersBookmarked": chaptersBookmarked,
             "lastRead": lastRead,
-            "bookmarks": bookmarks
+            "bookmarks": bookmarks,
+            "dailyChapterCounts": dailyChapterCounts
         ]
         if let plan = readingPlan {
             dict["readingPlan"] = plan.dictionary
@@ -55,5 +61,9 @@ extension UserProfile {
 
     var totalChaptersRead: Int {
         chaptersRead.values.reduce(0) { $0 + $1.count }
+    }
+
+    var todayChaptersRead: Int {
+        dailyChapterCounts[Date().isoDateString] ?? 0
     }
 }

--- a/ViewModels/AuthViewModel.swift
+++ b/ViewModels/AuthViewModel.swift
@@ -130,6 +130,8 @@ class AuthViewModel: ObservableObject {
         if !set.contains(chapter) {
             set.insert(chapter)
             profile.chaptersRead[bookId] = Array(set).sorted()
+            let key = Date().isoDateString
+            profile.dailyChapterCounts[key, default: 0] += 1
         }
         profile.lastRead[bookId] = ["chapter": chapter, "verse": verse]
         profile.lastReadBookId = bookId

--- a/Views/DailyProgressCircle.swift
+++ b/Views/DailyProgressCircle.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct DailyProgressCircle: View {
+    var progress: Double
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.gray.opacity(0.3), lineWidth: 12)
+            Circle()
+                .trim(from: 0, to: CGFloat(min(progress, 1)))
+                .stroke(
+                    AngularGradient(gradient: Gradient(colors: [Color.green, Color.green.opacity(0.7)]), center: .center),
+                    style: StrokeStyle(lineWidth: 12, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+                .shadow(color: Color.green.opacity(0.7), radius: 6)
+            Text("\(Int(progress * 100))%")
+                .font(.caption)
+                .bold()
+        }
+        .frame(width: 80, height: 80)
+    }
+}
+
+struct DailyProgressCircle_Previews: PreviewProvider {
+    static var previews: some View {
+        DailyProgressCircle(progress: 0.4)
+    }
+}

--- a/Views/HomeView.swift
+++ b/Views/HomeView.swift
@@ -47,16 +47,31 @@ struct HomeView: View {
                         .padding(.top, 4)
                     }
 
-                        if let last = lastReadReference() {
-                            NavigationLink(destination: ChapterView(chapterId: last.ref, bibleId: defaultBibleId, highlightVerse: last.verse)) {
-                                Text("Continue Reading")
-                                    .frame(maxWidth: .infinity)
-                                    .padding()
-                                    .background(Color.green)
-                                    .foregroundColor(.white)
-                                    .cornerRadius(12)
+                    if let plan = authViewModel.profile.readingPlan {
+                        let goal = plan.chaptersForDate(Date())
+                        let read = authViewModel.profile.todayChaptersRead
+                        if goal > 0 {
+                            VStack(spacing: 12) {
+                                Text("Today's Progress")
+                                    .font(.headline)
+                                DailyProgressCircle(progress: Double(read) / Double(goal))
+                                Text("You've read \(read) of \(goal) chapters today")
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                                if read < goal, let last = lastReadReference() {
+                                    NavigationLink(destination: ChapterView(chapterId: last.ref, bibleId: defaultBibleId, highlightVerse: last.verse)) {
+                                        Text("Continue where you left off")
+                                            .frame(maxWidth: .infinity)
+                                            .padding()
+                                            .background(Color.green)
+                                            .foregroundColor(.white)
+                                            .cornerRadius(12)
+                                    }
+                                }
                             }
+                            .frame(maxWidth: .infinity)
                         }
+                    }
                     } else {
                         VStack(spacing: 16) {
                             Text("No reading plan yet")


### PR DESCRIPTION
## Summary
- track daily chapter counts in `UserProfile`
- update `ReadingPlan` to compute chapters for a given date
- add helper `Date` extensions
- update chapter marking to count daily progress
- show a modern daily progress circle on the home screen

## Testing
- `swiftc -emit-sil *.swift Models/*.swift ViewModels/*.swift Views/*.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6869bfedb89c832eabc15d27407ea543