### PR TITLE
Add home settings and themes

### DIFF
--- a/AppSettings.swift
+++ b/AppSettings.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+enum FontSizeOption: String, CaseIterable, Codable {
+    case small, medium, large
+    var pointSize: CGFloat {
+        switch self {
+        case .small: return 14
+        case .medium: return 17
+        case .large: return 20
+        }
+    }
+}
+
+enum FontChoice: String, CaseIterable, Codable {
+    case system, serif, monospace
+    func font(size: CGFloat) -> Font {
+        switch self {
+        case .system: return .system(size: size)
+        case .serif: return .system(size: size, design: .serif)
+        case .monospace: return .system(size: size, design: .monospaced)
+        }
+    }
+}
+
+enum VerseSpacingOption: String, CaseIterable, Codable {
+    case compact, regular, roomy
+    var spacing: CGFloat {
+        switch self {
+        case .compact: return 4
+        case .regular: return 8
+        case .roomy: return 14
+        }
+    }
+}
+
+enum AppTheme: String, CaseIterable, Codable {
+    case light, dark, ocean, forest, sepia
+
+    var name: String {
+        switch self {
+        case .light: return "Light"
+        case .dark: return "Dark"
+        case .ocean: return "Ocean"
+        case .forest: return "Forest"
+        case .sepia: return "Sepia"
+        }
+    }
+
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .light, .ocean, .sepia: return .light
+        case .dark, .forest: return .dark
+        }
+    }
+
+    var accentColor: Color {
+        switch self {
+        case .light: return .blue
+        case .dark: return .orange
+        case .ocean: return .teal
+        case .forest: return .green
+        case .sepia: return .brown
+        }
+    }
+}

--- a/Models/UserProfile.swift
+++ b/Models/UserProfile.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 struct UserProfile {
     var chaptersRead: [String: [Int]]
@@ -13,6 +14,12 @@ struct UserProfile {
     var chapterNotes: [String: String]
     /// User notes for individual verses keyed by chapter id then verse number
     var verseNotes: [String: [String: String]]
+    // App settings
+    var bibleId: String
+    var fontSize: FontSizeOption
+    var fontChoice: FontChoice
+    var verseSpacing: VerseSpacingOption
+    var theme: AppTheme
 
     init(chaptersRead: [String: [Int]] = [:],
          chaptersBookmarked: [String: [Int]] = [:],
@@ -22,7 +29,12 @@ struct UserProfile {
          lastReadBookId: String? = nil,
          dailyChapterCounts: [String: Int] = [:],
          chapterNotes: [String: String] = [:],
-         verseNotes: [String: [String: String]] = [:]) {
+         verseNotes: [String: [String: String]] = [:],
+         bibleId: String = defaultBibleId,
+         fontSize: FontSizeOption = .medium,
+         fontChoice: FontChoice = .system,
+         verseSpacing: VerseSpacingOption = .regular,
+         theme: AppTheme = .light) {
         self.chaptersRead = chaptersRead
         self.chaptersBookmarked = chaptersBookmarked
         self.lastRead = lastRead
@@ -32,6 +44,11 @@ struct UserProfile {
         self.dailyChapterCounts = dailyChapterCounts
         self.chapterNotes = chapterNotes
         self.verseNotes = verseNotes
+        self.bibleId = bibleId
+        self.fontSize = fontSize
+        self.fontChoice = fontChoice
+        self.verseSpacing = verseSpacing
+        self.theme = theme
     }
 }
 
@@ -49,7 +66,12 @@ extension UserProfile {
         let dailyCounts = dict["dailyChapterCounts"] as? [String: Int] ?? [:]
         let chapterNotes = dict["chapterNotes"] as? [String: String] ?? [:]
         let verseNotes = dict["verseNotes"] as? [String: [String: String]] ?? [:]
-        self.init(chaptersRead: chaptersRead, chaptersBookmarked: chaptersBookmarked, lastRead: lastRead, readingPlan: plan, bookmarks: bookmarks, lastReadBookId: lastBook, dailyChapterCounts: dailyCounts, chapterNotes: chapterNotes, verseNotes: verseNotes)
+        let bibleId = dict["bibleId"] as? String ?? defaultBibleId
+        let fontSize = FontSizeOption(rawValue: dict["fontSize"] as? String ?? FontSizeOption.medium.rawValue) ?? .medium
+        let fontChoice = FontChoice(rawValue: dict["fontChoice"] as? String ?? FontChoice.system.rawValue) ?? .system
+        let verseSpacing = VerseSpacingOption(rawValue: dict["verseSpacing"] as? String ?? VerseSpacingOption.regular.rawValue) ?? .regular
+        let theme = AppTheme(rawValue: dict["theme"] as? String ?? AppTheme.light.rawValue) ?? .light
+        self.init(chaptersRead: chaptersRead, chaptersBookmarked: chaptersBookmarked, lastRead: lastRead, readingPlan: plan, bookmarks: bookmarks, lastReadBookId: lastBook, dailyChapterCounts: dailyCounts, chapterNotes: chapterNotes, verseNotes: verseNotes, bibleId: bibleId, fontSize: fontSize, fontChoice: fontChoice, verseSpacing: verseSpacing, theme: theme)
     }
 
     var dictionary: [String: Any] {
@@ -60,7 +82,12 @@ extension UserProfile {
             "bookmarks": bookmarks,
             "dailyChapterCounts": dailyChapterCounts,
             "chapterNotes": chapterNotes,
-            "verseNotes": verseNotes
+            "verseNotes": verseNotes,
+            "bibleId": bibleId,
+            "fontSize": fontSize.rawValue,
+            "fontChoice": fontChoice.rawValue,
+            "verseSpacing": verseSpacing.rawValue,
+            "theme": theme.rawValue
         ]
         if let plan = readingPlan {
             dict["readingPlan"] = plan.dictionary

--- a/ViewModels/AuthViewModel.swift
+++ b/ViewModels/AuthViewModel.swift
@@ -213,4 +213,30 @@ class AuthViewModel: ObservableObject {
         }
         saveProfile()
     }
+
+    // MARK: - Settings
+    func updateBibleId(_ id: String) {
+        profile.bibleId = id
+        saveProfile()
+    }
+
+    func updateFontSize(_ size: FontSizeOption) {
+        profile.fontSize = size
+        saveProfile()
+    }
+
+    func updateFontChoice(_ choice: FontChoice) {
+        profile.fontChoice = choice
+        saveProfile()
+    }
+
+    func updateVerseSpacing(_ spacing: VerseSpacingOption) {
+        profile.verseSpacing = spacing
+        saveProfile()
+    }
+
+    func updateTheme(_ theme: AppTheme) {
+        profile.theme = theme
+        saveProfile()
+    }
 }

--- a/Views/BookmarksView.swift
+++ b/Views/BookmarksView.swift
@@ -11,7 +11,7 @@ struct BookmarksView: View {
         NavigationView {
             List {
                 ForEach(verses, id: \.id) { verse in
-                    NavigationLink(destination: ChapterView(chapterId: referencePrefix(for: verse.id), bibleId: defaultBibleId, highlightVerse: Int(verse.verseNumber))) {
+                    NavigationLink(destination: ChapterView(chapterId: referencePrefix(for: verse.id), bibleId: authViewModel.profile.bibleId, highlightVerse: Int(verse.verseNumber))) {
                         VStack(alignment: .leading) {
                             Text(verse.reference)
                                 .font(.headline)
@@ -56,7 +56,7 @@ struct BookmarksView: View {
         verses = []
         let ids = authViewModel.profile.bookmarks
         for id in ids {
-            BibleAPI.shared.fetchVerse(reference: id) { result in
+            BibleAPI.shared.fetchVerse(reference: id, bibleId: authViewModel.profile.bibleId) { result in
                 if case .success(let verse) = result {
                     DispatchQueue.main.async {
                         verses.append(verse)

--- a/Views/ChapterView.swift
+++ b/Views/ChapterView.swift
@@ -82,7 +82,7 @@ struct ChapterView: View {
             } else {
                 ScrollViewReader { proxy in
                     ScrollView {
-                        LazyVStack(alignment: .leading, spacing: 6) {
+                        LazyVStack(alignment: .leading, spacing: authViewModel.profile.verseSpacing.spacing) {
                             ForEach(verses, id: \.id) { verse in
                                 VerseRowView(verse: verse, isHighlighted: verse.id == highlightedVerseId)
                                     .id(verse.id)
@@ -340,6 +340,7 @@ struct VerseRowView: View {
                 }
             }
             Text(verse.cleanedText)
+                .font(authViewModel.profile.fontChoice.font(size: authViewModel.profile.fontSize.pointSize))
         }
         .padding(.vertical, 2)
         .padding(.horizontal, 4)

--- a/Views/ExpandedBookView.swift
+++ b/Views/ExpandedBookView.swift
@@ -66,7 +66,7 @@ struct ExpandedBookView: View {
                 destination: selectedChapter.map {
                     ChapterView(
                         chapterId: "\($0.book.id).\($0.chapter)",
-                        bibleId: defaultBibleId,
+                        bibleId: authViewModel.profile.bibleId,
                         highlightVerse: $0.verse
                     )
                 },

--- a/Views/HomeSettingsView.swift
+++ b/Views/HomeSettingsView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+struct HomeSettingsView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+
+    private let bibleOptions: [(name: String, id: String)] = [
+        ("ESV", "179568874c45066f-01"),
+        ("KJV", "de4e12af7f28f599-02"),
+        ("NIV", "06125adad2d5898a-01"),
+        ("NKJV", "b4cb7bdb3da2f761-01"),
+        ("NLT", "fae20f318bf5bc7c-02")
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Settings")
+                .font(.headline)
+                .padding(.bottom, 4)
+
+            VStack(spacing: 12) {
+                Picker("Bible Version", selection: Binding(
+                    get: { authViewModel.profile.bibleId },
+                    set: { authViewModel.updateBibleId($0) })) {
+                    ForEach(bibleOptions, id: \.id) { opt in
+                        Text(opt.name).tag(opt.id)
+                    }
+                }
+                .pickerStyle(.menu)
+
+                Picker("Font Size", selection: Binding(
+                    get: { authViewModel.profile.fontSize },
+                    set: { authViewModel.updateFontSize($0) })) {
+                    ForEach(FontSizeOption.allCases, id: \.self) { size in
+                        Text(size.rawValue.capitalized).tag(size)
+                    }
+                }
+                .pickerStyle(.menu)
+
+                Picker("Font", selection: Binding(
+                    get: { authViewModel.profile.fontChoice },
+                    set: { authViewModel.updateFontChoice($0) })) {
+                    ForEach(FontChoice.allCases, id: \.self) { font in
+                        Text(font.rawValue.capitalized).tag(font)
+                    }
+                }
+                .pickerStyle(.menu)
+
+                Picker("Verse Spacing", selection: Binding(
+                    get: { authViewModel.profile.verseSpacing },
+                    set: { authViewModel.updateVerseSpacing($0) })) {
+                    ForEach(VerseSpacingOption.allCases, id: \.self) { space in
+                        Text(space.rawValue.capitalized).tag(space)
+                    }
+                }
+                .pickerStyle(.menu)
+
+                Picker("Theme", selection: Binding(
+                    get: { authViewModel.profile.theme },
+                    set: { authViewModel.updateTheme($0) })) {
+                    ForEach(AppTheme.allCases, id: \.self) { theme in
+                        Text(theme.name).tag(theme)
+                    }
+                }
+                .pickerStyle(.menu)
+            }
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color(.secondarySystemBackground))
+            )
+        }
+        .padding(.top)
+    }
+}

--- a/Views/HomeView.swift
+++ b/Views/HomeView.swift
@@ -59,7 +59,7 @@ struct HomeView: View {
                                     .font(.subheadline)
                                     .foregroundColor(.secondary)
                                 if read < goal, let last = lastReadReference() {
-                                    NavigationLink(destination: ChapterView(chapterId: last.ref, bibleId: defaultBibleId, highlightVerse: last.verse)) {
+                                    NavigationLink(destination: ChapterView(chapterId: last.ref, bibleId: authViewModel.profile.bibleId, highlightVerse: last.verse)) {
                                         Text("Continue where you left off")
                                             .frame(maxWidth: .infinity)
                                             .padding()
@@ -83,6 +83,7 @@ struct HomeView: View {
                                 .cornerRadius(12)
                         }
                     }
+                    HomeSettingsView()
                     Spacer()
                 }
                 .padding()

--- a/Views/OverviewVIew.swift
+++ b/Views/OverviewVIew.swift
@@ -117,7 +117,7 @@ class BibleSearchManager: ObservableObject {
         for (index, result) in searchResults.enumerated() where result.type == .verse {
             if let chapter = result.chapter, let verse = result.verse {
                 let ref = "\(result.book.id).\(chapter).\(verse)"
-                BibleAPI.shared.fetchVerse(reference: ref, bibleId: defaultBibleId) { res in
+                BibleAPI.shared.fetchVerse(reference: ref, bibleId: authViewModel.profile.bibleId) { res in
                     if case .success(let verseObj) = res {
                         DispatchQueue.main.async {
                             if index < self.searchResults.count {
@@ -345,7 +345,7 @@ struct OverviewView: View {
                     destination: selectedChapter.map {
                         ChapterView(
                             chapterId: "\($0.book.id).\($0.chapter)",
-                            bibleId: defaultBibleId,
+                            bibleId: authViewModel.profile.bibleId,
                             highlightVerse: $0.verse
                         )
                     },

--- a/Views/RootView.swift
+++ b/Views/RootView.swift
@@ -27,6 +27,8 @@ struct RootView: View {
                 }
             }
         }
+        .preferredColorScheme(authViewModel.profile.theme.colorScheme)
+        .tint(authViewModel.profile.theme.accentColor)
         .task {
             authViewModel.start()
         }

--- a/Views/StudyView.swift
+++ b/Views/StudyView.swift
@@ -18,7 +18,7 @@ struct StudyView: View {
                             NavigationLink(
                                 destination: ChapterView(
                                     chapterId: referencePrefix(for: verse.id),
-                                    bibleId: defaultBibleId,
+                                    bibleId: authViewModel.profile.bibleId,
                                     highlightVerse: Int(verse.verseNumber)
                                 )
                             ) {
@@ -49,7 +49,7 @@ struct StudyView: View {
                                 NavigationLink(
                                     destination: ChapterView(
                                         chapterId: entry.chapterId,
-                                        bibleId: defaultBibleId,
+                                        bibleId: authViewModel.profile.bibleId,
                                         highlightVerse: entry.verse
                                     )
                                 ) {


### PR DESCRIPTION
## Summary
- add theme and font configuration models
- store new user settings in profile
- allow updating settings with AuthViewModel helpers
- add modern Home settings UI
- apply selected bible, font, spacing, and theme across views

## Testing
- `swiftc -o /tmp/testcompile *.swift Models/*.swift ViewModels/*.swift Views/*.swift Networking/*.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6869cd12c06c832e90bc0eef0488442d