### PR TITLE
Fix bible id usage in search manager

### DIFF
--- a/Views/ChapterView.swift
+++ b/Views/ChapterView.swift
@@ -116,7 +116,13 @@ struct ChapterView: View {
                 }
             }
         }
-        .onAppear(perform: loadChapter)
+        .onAppear {
+            loadChapter()
+            searchManager.bibleId = authViewModel.profile.bibleId
+        }
+        .onChange(of: authViewModel.profile.bibleId) { newId in
+            searchManager.bibleId = newId
+        }
         .onReceive(booksNav.$resetTrigger.dropFirst()) { _ in
             dismiss()
         }

--- a/Views/ExpandedBookView.swift
+++ b/Views/ExpandedBookView.swift
@@ -93,7 +93,13 @@ struct ExpandedBookView: View {
                 )
             ) { EmptyView() }
         }
-        .onAppear { searchManager.scopeBook = book }
+        .onAppear {
+            searchManager.scopeBook = book
+            searchManager.bibleId = authViewModel.profile.bibleId
+        }
+        .onChange(of: authViewModel.profile.bibleId) { newId in
+            searchManager.bibleId = newId
+        }
         .onReceive(booksNav.$resetTrigger.dropFirst()) { _ in
             dismiss()
         }

--- a/Views/OverviewVIew.swift
+++ b/Views/OverviewVIew.swift
@@ -37,6 +37,7 @@ class BibleSearchManager: ObservableObject {
     @Published var isSearching = false
     @Published var showingSearchResults = false
     @Published var scopeBook: BibleBook? = nil
+    @Published var bibleId: String = defaultBibleId
     
     private var searchTimer: Timer?
     private let allBooks: [BibleBook]
@@ -117,7 +118,7 @@ class BibleSearchManager: ObservableObject {
         for (index, result) in searchResults.enumerated() where result.type == .verse {
             if let chapter = result.chapter, let verse = result.verse {
                 let ref = "\(result.book.id).\(chapter).\(verse)"
-                BibleAPI.shared.fetchVerse(reference: ref, bibleId: authViewModel.profile.bibleId) { res in
+                BibleAPI.shared.fetchVerse(reference: ref, bibleId: bibleId) { res in
                     if case .success(let verseObj) = res {
                         DispatchQueue.main.async {
                             if index < self.searchResults.count {
@@ -390,6 +391,12 @@ struct OverviewView: View {
         .sheet(isPresented: $showBookmarks) {
             BookmarksView()
                 .environmentObject(booksNav)
+        }
+        .onAppear {
+            searchManager.bibleId = authViewModel.profile.bibleId
+        }
+        .onChange(of: authViewModel.profile.bibleId) { newId in
+            searchManager.bibleId = newId
         }
     }
     


### PR DESCRIPTION
## Summary
- store bible ID in `BibleSearchManager`
- use the stored bible ID when fetching verse previews
- sync bible ID from `AuthViewModel` in views that own a search manager

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6869cf072a10832eb825d9f074fef5a6