### PR TITLE
Centralize chapter navigation

### DIFF
--- a/ViewModels/BooksNavigationManager.swift
+++ b/ViewModels/BooksNavigationManager.swift
@@ -1,23 +1,27 @@
 import Foundation
 import SwiftUI
 
-/// Observable object that allows views in the Books navigation stack
-/// to programmatically pop back to the root "Books" page.
-class BooksNavigationManager: ObservableObject {
-    /// Changing this value notifies all views to dismiss themselves.
-    @Published private(set) var resetTrigger: Int = 0
+/// Destinations for the Books navigation stack.
+enum BooksRoute: Hashable {
+    case expandedBook(String)
+    case chapter(bookId: String, chapter: Int, highlight: Int?)
+}
 
-    /// Call to trigger a pop-to-root of all active views in the Books stack.
-    ///
-    /// Sends several sequential increments so that each active view
-    /// in the stack receives a dismissal signal even if others are
-    /// still animating out. This avoids the back button effect where
-    /// only the top view closes.
-    func popToRoot() {
-        for step in 0..<5 { // support up to 5 stacked views
-            DispatchQueue.main.asyncAfter(deadline: .now() + Double(step) * 0.05) {
-                self.resetTrigger += 1
-            }
-        }
+/// Observable object managing navigation within the Books tab.
+class BooksNavigationManager: ObservableObject {
+    /// The navigation path for the Books stack.
+    @Published var path = NavigationPath()
+
+    /// Push a chapter onto the stack and switch to the Books tab.
+    func openChapter(bookId: String, chapter: Int, highlight: Int? = nil,
+                     tabManager: TabSelectionManager) {
+        tabManager.selection = .books
+        path.append(BooksRoute.chapter(bookId: bookId, chapter: chapter, highlight: highlight))
+    }
+
+    /// Return to the root Books view and select the Books tab.
+    func popToRoot(tabManager: TabSelectionManager) {
+        tabManager.selection = .books
+        path = NavigationPath()
     }
 }

--- a/ViewModels/TabSelectionManager.swift
+++ b/ViewModels/TabSelectionManager.swift
@@ -1,0 +1,14 @@
+import Foundation
+import SwiftUI
+
+/// Enum representing the available tabs in the application.
+enum AppTab: Hashable {
+    case home
+    case books
+    case study
+}
+
+/// Observable object that stores the currently selected tab.
+class TabSelectionManager: ObservableObject {
+    @Published var selection: AppTab = .home
+}

--- a/Views/ChapterView.swift
+++ b/Views/ChapterView.swift
@@ -7,6 +7,7 @@ struct ChapterView: View {
 
     @EnvironmentObject var authViewModel: AuthViewModel
     @EnvironmentObject var booksNav: BooksNavigationManager
+    @EnvironmentObject var tabManager: TabSelectionManager
     @Environment(\.dismiss) private var dismiss
     
     @State private var verses: [Verse] = []
@@ -122,9 +123,6 @@ struct ChapterView: View {
         }
         .onChange(of: authViewModel.profile.bibleId) { newId in
             searchManager.bibleId = newId
-        }
-        .onReceive(booksNav.$resetTrigger.dropFirst()) { _ in
-            dismiss()
         }
         .navigationBarBackButtonHidden(true)
         .toolbar {
@@ -297,7 +295,7 @@ struct ChapterView: View {
     }
 
     private func backToBooks() {
-        booksNav.popToRoot()
+        booksNav.popToRoot(tabManager: tabManager)
     }
 
     private func openExpandedBook() {

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -2,22 +2,52 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject private var booksNavigationManager = BooksNavigationManager()
+    @StateObject private var tabManager = TabSelectionManager()
+    @EnvironmentObject var authViewModel: AuthViewModel
 
     var body: some View {
         ZStack {
-            TabView {
+            TabView(selection: $tabManager.selection) {
                 // Home tab
                 HomeView()
                     .tabItem {
                         Image(systemName: "house")
                         Text("Home")
                     }
+                    .tag(AppTab.home)
 
                 // "Books" tab: the main Bible navigation/reading UI
                 NavigationView {
-                    NavigationStack {
+                    NavigationStack(path: $booksNavigationManager.path) {
                         VStack(spacing: 0) {
                             OverviewView()
+                        }
+                        .navigationDestination(for: BooksRoute.self) { route in
+                            switch route {
+                            case .expandedBook(let id):
+                                if let book = (oldTestamentCategories + newTestamentCategories)
+                                    .flatMap({ $0.books })
+                                    .first(where: { $0.id == id }) {
+                                    ExpandedBookView(
+                                        book: book,
+                                        searchManager: BibleSearchManager(),
+                                        chaptersRead: authViewModel.profile.chaptersRead.mapValues { Set($0) },
+                                        chaptersBookmarked: authViewModel.profile.chaptersBookmarked.mapValues { Set($0) },
+                                        lastRead: authViewModel.profile.lastRead.reduce(into: [String: (chapter: Int, verse: Int)]()) { partial, item in
+                                            partial[item.key] = (item.value["chapter"] ?? 1, item.value["verse"] ?? 0)
+                                        }
+                                    ) { b, chapter in
+                                        booksNavigationManager.path.append(
+                                            BooksRoute.chapter(bookId: b.id, chapter: chapter, highlight: nil))
+                                    }
+                                }
+                            case .chapter(let bid, let chap, let highlight):
+                                ChapterView(
+                                    chapterId: "\(bid).\(chap)",
+                                    bibleId: authViewModel.profile.bibleId,
+                                    highlightVerse: highlight
+                                )
+                            }
                         }
                     }
                     .environmentObject(booksNavigationManager)
@@ -26,6 +56,7 @@ struct ContentView: View {
                     Image(systemName: "book.closed")
                     Text("Books")
                 }
+                .tag(AppTab.books)
 
                 StudyView()
                     .environmentObject(booksNavigationManager)
@@ -33,8 +64,10 @@ struct ContentView: View {
                         Image(systemName: "books.vertical")
                         Text("Study")
                     }
+                    .tag(AppTab.study)
             }
             .environmentObject(booksNavigationManager)
+            .environmentObject(tabManager)
         }
     }
 }

--- a/Views/HomeView.swift
+++ b/Views/HomeView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct HomeView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
+    @EnvironmentObject var booksNav: BooksNavigationManager
+    @EnvironmentObject var tabManager: TabSelectionManager
 
     @State private var showPlanCreator = false
     @State private var editingPlan: ReadingPlan? = nil
@@ -59,7 +61,12 @@ struct HomeView: View {
                                     .font(.subheadline)
                                     .foregroundColor(.secondary)
                                 if read < goal, let last = lastReadReference() {
-                                    NavigationLink(destination: ChapterView(chapterId: last.ref, bibleId: authViewModel.profile.bibleId, highlightVerse: last.verse)) {
+                                    Button(action: {
+                                        let parts = last.ref.split(separator: ".")
+                                        let bookId = String(parts[0])
+                                        let chapter = Int(parts[1]) ?? 1
+                                        booksNav.openChapter(bookId: bookId, chapter: chapter, highlight: last.verse, tabManager: tabManager)
+                                    }) {
                                         Text("Continue where you left off")
                                             .frame(maxWidth: .infinity)
                                             .padding()

--- a/Views/StudyView.swift
+++ b/Views/StudyView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct StudyView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
     @EnvironmentObject var booksNav: BooksNavigationManager
+    @EnvironmentObject var tabManager: TabSelectionManager
     @State private var bookmarkedVerses: [Verse] = []
 
     private var allBooks: [BibleBook] {
@@ -15,13 +16,14 @@ struct StudyView: View {
                 if !bookmarkedVerses.isEmpty {
                     Section(header: Text("Your Bookmarks")) {
                         ForEach(bookmarkedVerses, id: \.id) { verse in
-                            NavigationLink(
-                                destination: ChapterView(
-                                    chapterId: referencePrefix(for: verse.id),
-                                    bibleId: authViewModel.profile.bibleId,
-                                    highlightVerse: Int(verse.verseNumber)
+                            Button(action: {
+                                booksNav.openChapter(
+                                    bookId: String(verse.id.split(separator: ".")[0]),
+                                    chapter: Int(verse.id.split(separator: ".")[1]) ?? 1,
+                                    highlight: Int(verse.verseNumber),
+                                    tabManager: tabManager
                                 )
-                            ) {
+                            }) {
                                 VStack(alignment: .leading) {
                                     Text(verse.reference).font(.headline)
                                     Text(verse.cleanedText)
@@ -46,13 +48,14 @@ struct StudyView: View {
                     if let entries = grouped[book.id] {
                         Section(header: Text(book.name)) {
                             ForEach(entries) { entry in
-                                NavigationLink(
-                                    destination: ChapterView(
-                                        chapterId: entry.chapterId,
-                                        bibleId: authViewModel.profile.bibleId,
-                                        highlightVerse: entry.verse
+                                Button(action: {
+                                    booksNav.openChapter(
+                                        bookId: entry.bookId,
+                                        chapter: entry.chapter,
+                                        highlight: entry.verse,
+                                        tabManager: tabManager
                                     )
-                                ) {
+                                }) {
                                     VStack(alignment: .leading) {
                                         Text(entry.displayRef).font(.headline)
                                         Text(entry.text)


### PR DESCRIPTION
## Summary
- introduce `TabSelectionManager` for global tab selection
- rework `BooksNavigationManager` to manage a shared `NavigationPath`
- update `ContentView` to use the new managers and navigation destinations
- route chapter openings from Home and Study through the Books tab
- simplify pop-to-root behaviour

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6869d66fe930832e8434391d169e78b3