### PR TITLE
Fix BooksRoute usage in navigation

### DIFF
--- a/Views/ExpandedBookView.swift
+++ b/Views/ExpandedBookView.swift
@@ -106,7 +106,7 @@ struct ExpandedBookView: View {
     private func handleSearchResult(_ result: BibleSearchResult) {
         switch result.type {
         case .book:
-            booksNav.path.append(.expandedBook(result.book.id))
+            booksNav.path.append(BooksRoute.expandedBook(result.book.id))
             searchManager.clearSearch()
         case .chapter:
             onSelectChapter(result.book, result.chapter ?? 1)

--- a/Views/OverviewVIew.swift
+++ b/Views/OverviewVIew.swift
@@ -288,7 +288,7 @@ struct OverviewView: View {
                                 )
                             },
                             onExpandBook: { book in
-                                booksNav.path.append(.expandedBook(book.id))
+                                booksNav.path.append(BooksRoute.expandedBook(book.id))
                             }
                         )
                         TestamentSection(
@@ -304,7 +304,7 @@ struct OverviewView: View {
                                 )
                             },
                             onExpandBook: { book in
-                                booksNav.path.append(.expandedBook(book.id))
+                                booksNav.path.append(BooksRoute.expandedBook(book.id))
                             }
                         )
                         }
@@ -357,7 +357,7 @@ struct OverviewView: View {
     private func handleSearchResultSelection(_ result: BibleSearchResult) {
         switch result.type {
         case .book:
-            booksNav.path.append(.expandedBook(result.book.id))
+            booksNav.path.append(BooksRoute.expandedBook(result.book.id))
             searchManager.clearSearch()
         case .chapter:
             booksNav.path.append(


### PR DESCRIPTION
## Summary
- specify `BooksRoute` when appending `expandedBook` destinations

## Testing
- `swift --version`
- `swiftc Views/ExpandedBookView.swift -o /tmp/ExpandedBookView` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6869d9342da0832e8bd49449be3b5ba1