### PR TITLE
Fix progress view gradient tint

### DIFF
--- a/Views/CelebrationOverlay.swift
+++ b/Views/CelebrationOverlay.swift
@@ -55,7 +55,8 @@ struct CelebrationProgress: View {
         .foregroundColor(.yellow)
         .font(.headline)
       ProgressView(value: progress)
-        .progressViewStyle(LinearProgressViewStyle(tint: gradient))
+        .progressViewStyle(LinearProgressViewStyle())
+        .tint(gradient)
         .frame(width: 220)
     }
     .padding(12)


### PR DESCRIPTION
## Summary
- make `CelebrationProgress` use `.tint(gradient)` instead of passing the gradient into `LinearProgressViewStyle`

## Testing
- `swift package describe` *(fails: no Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6869e0c90454832e930338bb6e931c51