### PR TITLE
Improve celebration progress fade

### DIFF
--- a/ViewModels/AuthViewModel.swift
+++ b/ViewModels/AuthViewModel.swift
@@ -264,7 +264,7 @@ class AuthViewModel: ObservableObject {
 
     private func triggerCelebration(_ event: CelebrationEvent) {
         celebrationEvent = event
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { [weak self] in
             if self?.celebrationEvent != nil {
                 self?.celebrationEvent = nil
             }

--- a/Views/CelebrationOverlay.swift
+++ b/Views/CelebrationOverlay.swift
@@ -11,33 +11,29 @@ enum CelebrationEvent {
 struct CelebrationOverlay: View {
   let event: CelebrationEvent?
   @Environment(\.colorScheme) private var scheme
+  @State private var show = false
+  @State private var currentEvent: CelebrationEvent?
 
   private var fadeColor: Color {
     scheme == .dark ? .black : .white
   }
 
   var body: some View {
-    if let event = event {
+    if let active = currentEvent {
       ZStack {
         fadeColor.opacity(0.6)
           .ignoresSafeArea()
           .transition(.opacity)
         VStack {
-          if case .book(let progress) = event {
+          if case .book(let progress) = active {
             CelebrationProgress(progress: progress)
               .padding(.top, 50)
             Spacer()
-          } else if case .bible = event {
+          } else if case .bible = active {
             CelebrationProgress(progress: 1)
               .padding(.top, 50)
-            Text("Congratulations! You've completed the Bible!")
-              .font(.title)
-              .fontWeight(.heavy)
-              .foregroundColor(.yellow)
-              .shadow(color: Color.yellow.opacity(0.7), radius: 6)
-              .padding(.top, 8)
             Spacer()
-          } else if case .chapter = event {
+          } else if case .chapter = active {
             ChapterProgressBar()
               .padding(.top, 50)
             Spacer()
@@ -51,7 +47,25 @@ struct CelebrationOverlay: View {
         }
       }
       .transition(.opacity)
-      .animation(.easeInOut(duration: 0.5), value: event != nil)
+      .animation(.easeInOut(duration: 0.35), value: show)
+      .opacity(show ? 1 : 0)
+      .onAppear {
+        currentEvent = event
+        withAnimation(.easeInOut(duration: 0.35)) { show = true }
+      }
+      .onChange(of: event) { newValue in
+        if let new = newValue {
+          currentEvent = new
+          withAnimation(.easeInOut(duration: 0.35)) { show = true }
+        } else {
+          withAnimation(.easeInOut(duration: 0.35)) { show = false }
+          DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+            if event == nil {
+              currentEvent = nil
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- tweak trigger delay for celebration messages to feel snappier
- remove Bible completion text and animate overlay opacity

## Testing
- `swiftc -parse Views/CelebrationOverlay.swift`
- `swiftc -parse ViewModels/AuthViewModel.swift`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6869e4665a58832e8afe1c4288dc78e6