### PR TITLE
Switch app to local Bible server

### DIFF
--- a/BibleConstants.swift
+++ b/BibleConstants.swift
@@ -5,4 +5,7 @@
 //  Created by Jonathan Hori on 7/3/25.
 //
 
-let defaultBibleId = "179568874c45066f-01"
+// Default translation database file used when none is specified.
+// This string corresponds to the SQLite database name on the
+// backend server providing Bible content.
+let defaultBibleId = "bible_kjv.sqlite"

--- a/Views/ChapterView.swift
+++ b/Views/ChapterView.swift
@@ -2,7 +2,8 @@ import SwiftUI
 
 struct ChapterView: View {
     let chapterId: String        // e.g. "GEN.1"
-    let bibleId: String          // e.g. "179568874c45066f-01"
+    // bibleId corresponds to the SQLite database file, e.g. "bible_kjv.sqlite"
+    let bibleId: String
     let highlightVerse: Int?
 
     @EnvironmentObject var authViewModel: AuthViewModel

--- a/Views/HomeSettingsView.swift
+++ b/Views/HomeSettingsView.swift
@@ -3,12 +3,13 @@ import SwiftUI
 struct HomeSettingsView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
 
+    // Bible translation options now map directly to SQLite database files
     private let bibleOptions: [(name: String, id: String)] = [
-        ("ESV", "179568874c45066f-01"),
-        ("KJV", "de4e12af7f28f599-02"),
-        ("NIV", "06125adad2d5898a-01"),
-        ("NKJV", "b4cb7bdb3da2f761-01"),
-        ("NLT", "fae20f318bf5bc7c-02")
+        ("DRA", "bible_dra.sqlite"),
+        ("ASV", "bible_asv.sqlite"),
+        ("DBY", "bible_dby.sqlite"),
+        ("KJV", "bible_kjv.sqlite"),
+        ("WYC", "bible_wyc.sqlite")
     ]
 
     @State private var fontSizeValue: Double = 1


### PR DESCRIPTION
## Summary
- point default bible to SQLite-based version
- configure BibleAPI for the local backend
- fetch verses through new `/db/query` endpoint
- update Bible selection list to use database files
- clarify comment about bibleId usage

## Testing
- `swift --version`
- `swiftc -parse Networking/BibleAPI.swift`
- `swiftc -parse Views/HomeSettingsView.swift`
- `swiftc -parse Views/ChapterView.swift`


------
https://chatgpt.com/codex/tasks/task_e_686aa23f1390832ebdbcd792b70c0f0a