### PR TITLE
Add donation section on Home screen

### DIFF
--- a/Views/DonateSectionView.swift
+++ b/Views/DonateSectionView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct DonateSectionView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("If you have enjoyed or received value from this app, consider supporting my projects here:")
+            Link("buymeacoffee.com/jonathanhori", destination: URL(string: "https://buymeacoffee.com/jonathanhori")!)
+                .foregroundColor(.blue)
+        }
+        .font(.footnote)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(.secondarySystemBackground))
+        )
+        .padding(.top)
+    }
+}
+
+struct DonateSectionView_Previews: PreviewProvider {
+    static var previews: some View {
+        DonateSectionView()
+    }
+}
+

--- a/Views/HomeView.swift
+++ b/Views/HomeView.swift
@@ -91,6 +91,7 @@ struct HomeView: View {
                         }
                     }
                     HomeSettingsView()
+                    DonateSectionView()
                     Spacer()
                 }
                 .padding()


### PR DESCRIPTION
## Summary
- add new `DonateSectionView` with a Buy Me a Coffee link
- embed `DonateSectionView` under the Home settings panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b383605a0832eb85043bbd3a67af5