### PR TITLE
Implement reset modal and modern setup screen

### DIFF
--- a/Views/FirstTimeSetupView.swift
+++ b/Views/FirstTimeSetupView.swift
@@ -4,8 +4,6 @@ struct FirstTimeSetupView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
     @AppStorage("setupComplete") private var setupComplete = false
 
-    @State private var step = 0
-    @State private var selectedTheme: AppTheme = .light
     private let bibleOptions: [(name: String, id: String)] = [
         ("DRA", "bible_dra.sqlite"),
         ("ASV", "bible_asv.sqlite"),
@@ -13,127 +11,94 @@ struct FirstTimeSetupView: View {
         ("KJV", "bible_kjv.sqlite"),
         ("WYC", "bible_wyc.sqlite")
     ]
+
     @State private var selectedBible: String = defaultBibleId
-    @State private var showPlanCreator = false
-    @State private var notificationsEnabled = false
-    @State private var notificationTime = Calendar.current.date(bySettingHour: 8, minute: 0, second: 0, of: Date()) ?? Date()
+    @State private var planName: String = "My Plan"
+    @State private var chaptersPerDay: Int = 1
+    @State private var startDate: Date = Date()
+    @State private var notificationsEnabled: Bool = false
+    @State private var notificationTime: Date = Calendar.current.date(bySettingHour: 8, minute: 0, second: 0, of: Date()) ?? Date()
 
     var body: some View {
-        ZStack {
-            TabView(selection: $step) {
-                themeStep.tag(0)
-                bibleStep.tag(1)
-                planStep.tag(2)
-                notificationStep.tag(3)
-            }
-            .tabViewStyle(PageTabViewStyle(indexDisplayMode: .always))
-            .animation(.easeInOut, value: step)
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 24) {
+                    Text("Welcome to VerseReminder")
+                        .font(.largeTitle).bold()
+                        .padding(.top)
 
-            VStack {
-                Spacer()
-                HStack {
-                    if step > 0 {
-                        Button("Back") { step -= 1 }
+                    QuickSettingsPanel()
+                        .environmentObject(authViewModel)
+
+                    VStack(alignment: .leading, spacing: 16) {
+                        Text("Bible Version")
+                            .font(.headline)
+                        Picker("Bible", selection: $selectedBible) {
+                            ForEach(bibleOptions, id: .id) { opt in
+                                Text(opt.name).tag(opt.id)
+                            }
+                        }
+                        .pickerStyle(.menu)
                     }
-                    Spacer()
-                    if step < 3 {
-                        Button("Next") { step += 1 }
-                    } else {
-                        Button("Finish") {
-                            authViewModel.updateTheme(selectedTheme)
-                            authViewModel.updateBibleId(selectedBible)
-                            authViewModel.profile.readingPlan?.notificationsEnabled = notificationsEnabled
-                            authViewModel.profile.readingPlan?.notificationTimeMinutes = notificationsEnabled ? PlanCreatorView.dateToMinutes(notificationTime) : nil
-                            authViewModel.saveProfile()
-                            setupComplete = true
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+                    .background(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .fill(Color(.secondarySystemBackground))
+                    )
+
+                    VStack(alignment: .leading, spacing: 16) {
+                        Text("Reading Plan & Notifications")
+                            .font(.headline)
+                        TextField("Plan Name", text: $planName)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                        Stepper("Chapters per Day: \(chaptersPerDay)", value: $chaptersPerDay, in: 1...10)
+                        DatePicker("Start Date", selection: $startDate, displayedComponents: .date)
+                        Toggle("Enable Notifications", isOn: $notificationsEnabled)
+                        if notificationsEnabled {
+                            DatePicker("Notification Time", selection: $notificationTime, displayedComponents: .hourAndMinute)
                         }
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+                    .background(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .fill(Color(.secondarySystemBackground))
+                    )
+
+                    Button("Finish") {
+                        authViewModel.updateBibleId(selectedBible)
+                        let plan = ReadingPlan(
+                            name: planName,
+                            startDate: startDate,
+                            chaptersPerDay: chaptersPerDay,
+                            notificationsEnabled: notificationsEnabled,
+                            notificationTimeMinutes: notificationsEnabled ? PlanCreatorView.dateToMinutes(notificationTime) : nil,
+                            goalType: .chaptersPerDay,
+                            preset: .fullBible,
+                            nodes: []
+                        )
+                        authViewModel.setReadingPlan(plan)
+                        authViewModel.saveProfile()
+                        setupComplete = true
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .padding(.bottom)
                 }
                 .padding()
             }
-        }
-        .sheet(isPresented: $showPlanCreator) {
-            NavigationView { PlanCreatorView() }
-                .environmentObject(authViewModel)
-        }
-        .onAppear {
-            selectedTheme = authViewModel.profile.theme
-            selectedBible = authViewModel.profile.bibleId
-            notificationsEnabled = authViewModel.profile.readingPlan?.notificationsEnabled ?? false
-            if let mins = authViewModel.profile.readingPlan?.notificationTimeMinutes {
-                notificationTime = PlanCreatorView.minutesToDate(mins)
-            }
-        }
-    }
-
-    private var themeStep: some View {
-        VStack(spacing: 20) {
-            Text("Choose a Theme")
-                .font(.largeTitle).bold()
-            HStack {
-                ForEach(AppTheme.allCases, id: \.self) { theme in
-                    Button(action: {
-                        selectedTheme = theme
-                        authViewModel.updateTheme(theme)
-                    }) {
-                        Circle()
-                            .fill(theme.accentColor)
-                            .frame(width: 40, height: 40)
-                            .overlay(
-                                Image(systemName: "checkmark.circle.fill")
-                                    .opacity(selectedTheme == theme ? 1 : 0)
-                                    .foregroundColor(.white)
-                            )
-                    }
+            .navigationTitle("Setup")
+            .onAppear {
+                selectedBible = authViewModel.profile.bibleId
+                planName = authViewModel.profile.readingPlan?.name ?? "My Plan"
+                chaptersPerDay = authViewModel.profile.readingPlan?.chaptersPerDay ?? 1
+                startDate = authViewModel.profile.readingPlan?.startDate ?? Date()
+                notificationsEnabled = authViewModel.profile.readingPlan?.notificationsEnabled ?? false
+                if let mins = authViewModel.profile.readingPlan?.notificationTimeMinutes {
+                    notificationTime = PlanCreatorView.minutesToDate(mins)
                 }
             }
         }
-        .padding()
-    }
-
-    private var bibleStep: some View {
-        VStack(spacing: 20) {
-            Text("Select Bible Version")
-                .font(.largeTitle).bold()
-            Picker("Bible", selection: $selectedBible) {
-                ForEach(bibleOptions, id: \.id) { opt in
-                    Text(opt.name).tag(opt.id)
-                }
-            }
-            .pickerStyle(.wheel)
-            .frame(height: 150)
-            .onChange(of: selectedBible) { authViewModel.updateBibleId($0) }
-        }
-        .padding()
-    }
-
-    private var planStep: some View {
-        VStack(spacing: 20) {
-            Text("Create a Reading Plan")
-                .font(.largeTitle).bold()
-            if authViewModel.profile.readingPlan != nil {
-                Image(systemName: "checkmark.circle.fill")
-                    .foregroundColor(.green)
-                    .font(.largeTitle)
-            }
-            Button(authViewModel.profile.readingPlan == nil ? "Create Plan" : "Edit Plan") {
-                showPlanCreator = true
-            }
-            .buttonStyle(.borderedProminent)
-        }
-        .padding()
-    }
-
-    private var notificationStep: some View {
-        VStack(spacing: 20) {
-            Text("Notifications")
-                .font(.largeTitle).bold()
-            Toggle("Enable Notifications", isOn: $notificationsEnabled)
-            if notificationsEnabled {
-                DatePicker("Time", selection: $notificationTime, displayedComponents: .hourAndMinute)
-            }
-        }
-        .padding()
     }
 }
 

--- a/Views/HomeSettingsView.swift
+++ b/Views/HomeSettingsView.swift
@@ -3,147 +3,16 @@ import SwiftUI
 struct HomeSettingsView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
 
-    // Bible translation options now map directly to SQLite database files
-    private let bibleOptions: [(name: String, id: String)] = [
-        ("DRA", "bible_dra.sqlite"),
-        ("ASV", "bible_asv.sqlite"),
-        ("DBY", "bible_dby.sqlite"),
-        ("KJV", "bible_kjv.sqlite"),
-        ("WYC", "bible_wyc.sqlite")
-    ]
-
-    @State private var fontSizeValue: Double = 1
-    @State private var spacingValue: Double = 1
-
-    private func sliderValue(for size: FontSizeOption) -> Double {
-        switch size {
-        case .small: return 0
-        case .medium: return 1
-        case .large: return 2
-        }
-    }
-
-    private func fontSize(for value: Double) -> FontSizeOption {
-        if value < 0.5 { return .small }
-        else if value < 1.5 { return .medium }
-        else { return .large }
-    }
-
-    private func sliderValue(for spacing: VerseSpacingOption) -> Double {
-        switch spacing {
-        case .compact: return 0
-        case .regular: return 1
-        case .roomy: return 2
-        }
-    }
-
-    private func spacingOption(for value: Double) -> VerseSpacingOption {
-        if value < 0.5 { return .compact }
-        else if value < 1.5 { return .regular }
-        else { return .roomy }
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Quick Settings")
                 .font(.headline)
                 .padding(.bottom, 4)
 
-            VStack(spacing: 20) {
-                Picker("Bible Version", selection: Binding(
-                    get: { authViewModel.profile.bibleId },
-                    set: { authViewModel.updateBibleId($0) })) {
-                    ForEach(bibleOptions, id: \.id) { opt in
-                        Text(opt.name).tag(opt.id)
-                    }
-                }
-                .pickerStyle(.menu)
-
-                VStack(alignment: .leading) {
-                    Text("Text Size")
-                        .font(.subheadline)
-                    Slider(value: $fontSizeValue, in: 0...2, step: 1) {
-                        Text("Text Size")
-                    } minimumValueLabel: {
-                        Text("A")
-                            .font(.footnote)
-                    } maximumValueLabel: {
-                        Text("A")
-                            .font(.title)
-                    }
-                    .onChange(of: fontSizeValue) { newValue in
-                        authViewModel.updateFontSize(fontSize(for: newValue))
-                    }
-                }
-
-                VStack(alignment: .leading) {
-                    Text("Font Style")
-                        .font(.subheadline)
-                    HStack {
-                        ForEach(FontChoice.allCases, id: \.self) { choice in
-                            Button(action: {
-                                authViewModel.updateFontChoice(choice)
-                            }) {
-                                Text("Aa")
-                                    .font(choice.font(size: 20))
-                                    .padding(8)
-                                    .background(authViewModel.profile.fontChoice == choice ? Color.accentColor.opacity(0.2) : Color.clear)
-                                    .cornerRadius(8)
-                            }
-                        }
-                    }
-                }
-
-                VStack(alignment: .leading) {
-                    Text("Verse Spacing")
-                        .font(.subheadline)
-                    Slider(value: $spacingValue, in: 0...2, step: 1) {
-                        Text("Spacing")
-                    }
-                    .onChange(of: spacingValue) { newValue in
-                        authViewModel.updateVerseSpacing(spacingOption(for: newValue))
-                    }
-                }
-
-                VStack(alignment: .leading) {
-                    Text("Theme")
-                        .font(.subheadline)
-                    HStack {
-                        ForEach(AppTheme.allCases, id: \.self) { theme in
-                            Button(action: {
-                                authViewModel.updateTheme(theme)
-                            }) {
-                                Circle()
-                                    .fill(theme.accentColor)
-                                    .frame(width: 28, height: 28)
-                                    .overlay(
-                                        Circle()
-                                            .stroke(Color.primary, lineWidth: authViewModel.profile.theme == theme ? 3 : 0)
-                                    )
-                            }
-                        }
-                    }
-                }
-
-                VStack(alignment: .leading) {
-                    Text("Preview")
-                        .font(.subheadline)
-                    Text("In the beginning God created the heavens and the earth.\nAnd the Spirit of God was hovering over the face of the waters.")
-                        .font(authViewModel.profile.fontChoice.font(size: authViewModel.profile.fontSize.pointSize))
-                        .lineSpacing(authViewModel.profile.verseSpacing.spacing)
-                }
-            }
-            .frame(maxWidth: .infinity)
-            .padding()
-            .background(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(Color(.secondarySystemBackground))
-            )
-            }
-        .padding(.top)
-        .onAppear {
-            fontSizeValue = sliderValue(for: authViewModel.profile.fontSize)
-            spacingValue = sliderValue(for: authViewModel.profile.verseSpacing)
+            QuickSettingsPanel()
+                .environmentObject(authViewModel)
         }
+        .padding(.top)
     }
 }
+

--- a/Views/HomeView.swift
+++ b/Views/HomeView.swift
@@ -7,6 +7,7 @@ struct HomeView: View {
 
     @State private var showPlanCreator = false
     @State private var editingPlan: ReadingPlan? = nil
+    @State private var showReset = false
 
     var body: some View {
         NavigationView {
@@ -92,6 +93,13 @@ struct HomeView: View {
                     }
                     HomeSettingsView()
                     DonateSectionView()
+                    Button(role: .destructive) {
+                        showReset = true
+                    } label: {
+                        Text("Reset Account")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
                     Spacer()
                 }
                 .padding()
@@ -102,6 +110,10 @@ struct HomeView: View {
             }
             .sheet(item: $editingPlan) { plan in
                 NavigationView { PlanCreatorView(existingPlan: plan) }
+            }
+            .sheet(isPresented: $showReset) {
+                ResetAccountView()
+                    .environmentObject(authViewModel)
             }
         }
     }

--- a/Views/QuickSettingsPanel.swift
+++ b/Views/QuickSettingsPanel.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+
+struct QuickSettingsPanel: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+
+    private let bibleOptions: [(name: String, id: String)] = [
+        ("DRA", "bible_dra.sqlite"),
+        ("ASV", "bible_asv.sqlite"),
+        ("DBY", "bible_dby.sqlite"),
+        ("KJV", "bible_kjv.sqlite"),
+        ("WYC", "bible_wyc.sqlite")
+    ]
+
+    @State private var fontSizeValue: Double = 1
+    @State private var spacingValue: Double = 1
+
+    private func sliderValue(for size: FontSizeOption) -> Double {
+        switch size {
+        case .small: return 0
+        case .medium: return 1
+        case .large: return 2
+        }
+    }
+
+    private func fontSize(for value: Double) -> FontSizeOption {
+        if value < 0.5 { return .small }
+        else if value < 1.5 { return .medium }
+        else { return .large }
+    }
+
+    private func sliderValue(for spacing: VerseSpacingOption) -> Double {
+        switch spacing {
+        case .compact: return 0
+        case .regular: return 1
+        case .roomy: return 2
+        }
+    }
+
+    private func spacingOption(for value: Double) -> VerseSpacingOption {
+        if value < 0.5 { return .compact }
+        else if value < 1.5 { return .regular }
+        else { return .roomy }
+    }
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Picker("Bible Version", selection: Binding(
+                get: { authViewModel.profile.bibleId },
+                set: { authViewModel.updateBibleId($0) })) {
+                ForEach(bibleOptions, id: .id) { opt in
+                    Text(opt.name).tag(opt.id)
+                }
+            }
+            .pickerStyle(.menu)
+
+            VStack(alignment: .leading) {
+                Text("Text Size")
+                    .font(.subheadline)
+                Slider(value: $fontSizeValue, in: 0...2, step: 1) {
+                    Text("Text Size")
+                } minimumValueLabel: {
+                    Text("A").font(.footnote)
+                } maximumValueLabel: {
+                    Text("A").font(.title)
+                }
+                .onChange(of: fontSizeValue) { newValue in
+                    authViewModel.updateFontSize(fontSize(for: newValue))
+                }
+            }
+
+            VStack(alignment: .leading) {
+                Text("Font Style")
+                    .font(.subheadline)
+                HStack {
+                    ForEach(FontChoice.allCases, id: .self) { choice in
+                        Button(action: {
+                            authViewModel.updateFontChoice(choice)
+                        }) {
+                            Text("Aa")
+                                .font(choice.font(size: 20))
+                                .padding(8)
+                                .background(authViewModel.profile.fontChoice == choice ? Color.accentColor.opacity(0.2) : Color.clear)
+                                .cornerRadius(8)
+                        }
+                    }
+                }
+            }
+
+            VStack(alignment: .leading) {
+                Text("Verse Spacing")
+                    .font(.subheadline)
+                Slider(value: $spacingValue, in: 0...2, step: 1) {
+                    Text("Spacing")
+                }
+                .onChange(of: spacingValue) { newValue in
+                    authViewModel.updateVerseSpacing(spacingOption(for: newValue))
+                }
+            }
+
+            VStack(alignment: .leading) {
+                Text("Theme")
+                    .font(.subheadline)
+                HStack {
+                    ForEach(AppTheme.allCases, id: .self) { theme in
+                        Button(action: {
+                            authViewModel.updateTheme(theme)
+                        }) {
+                            Circle()
+                                .fill(theme.accentColor)
+                                .frame(width: 28, height: 28)
+                                .overlay(
+                                    Circle()
+                                        .stroke(Color.primary, lineWidth: authViewModel.profile.theme == theme ? 3 : 0)
+                                )
+                        }
+                    }
+                }
+            }
+
+            VStack(alignment: .leading) {
+                Text("Preview")
+                    .font(.subheadline)
+                Text("In the beginning God created the heavens and the earth.\nAnd the Spirit of God was hovering over the face of the waters.")
+                    .font(authViewModel.profile.fontChoice.font(size: authViewModel.profile.fontSize.pointSize))
+                    .lineSpacing(authViewModel.profile.verseSpacing.spacing)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(.secondarySystemBackground))
+        )
+        .onAppear {
+            fontSizeValue = sliderValue(for: authViewModel.profile.fontSize)
+            spacingValue = sliderValue(for: authViewModel.profile.verseSpacing)
+        }
+    }
+}
+
+struct QuickSettingsPanel_Previews: PreviewProvider {
+    static var previews: some View {
+        QuickSettingsPanel()
+            .environmentObject(AuthViewModel())
+    }
+}
+


### PR DESCRIPTION
## Summary
- embed a reusable `QuickSettingsPanel` for theme and font settings
- update HomeSettings to use the new quick settings panel
- redesign first time setup with inline settings, reading plan, and notifications
- add a reset account button under the Donate section on the Home screen

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686b3dcb0748832eb753a040edcdb6e4