### PR TITLE
Fix QuickSettingsPanel compilation error

### DIFF
--- a/Views/QuickSettingsPanel.swift
+++ b/Views/QuickSettingsPanel.swift
@@ -47,7 +47,7 @@ struct QuickSettingsPanel: View {
             Picker("Bible Version", selection: Binding(
                 get: { authViewModel.profile.bibleId },
                 set: { authViewModel.updateBibleId($0) })) {
-                ForEach(bibleOptions, id: .id) { opt in
+                ForEach(bibleOptions, id: \.id) { opt in
                     Text(opt.name).tag(opt.id)
                 }
             }


### PR DESCRIPTION
## Summary
- fix tuple `id` keyPath in QuickSettingsPanel

## Testing
- `swiftc Views/QuickSettingsPanel.swift -o /tmp/out` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686b41d7b6e8832e93723c23c87b2cf9