### PR TITLE
Revamp onboarding with slide-based setup

### DIFF
--- a/Views/FirstTimeSetupView.swift
+++ b/Views/FirstTimeSetupView.swift
@@ -1,104 +1,180 @@
 import SwiftUI
 
+/// Modernized multi-step setup flow displayed on first launch.
 struct FirstTimeSetupView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
     @AppStorage("setupComplete") private var setupComplete = false
 
+    // Full translation names used across the app
     private let bibleOptions: [(name: String, id: String)] = [
-        ("DRA", "bible_dra.sqlite"),
-        ("ASV", "bible_asv.sqlite"),
-        ("DBY", "bible_dby.sqlite"),
-        ("KJV", "bible_kjv.sqlite"),
-        ("WYC", "bible_wyc.sqlite")
+        ("Douay-Rheims", "bible_dra.sqlite"),
+        ("American Standard Version", "bible_asv.sqlite"),
+        ("Darby Bible", "bible_dby.sqlite"),
+        ("King James Version", "bible_kjv.sqlite"),
+        ("Wycliffe Bible", "bible_wyc.sqlite")
     ]
 
+    private let allDays = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"]
+
     @State private var selectedBible: String = defaultBibleId
-    @State private var planName: String = "My Plan"
     @State private var chaptersPerDay: Int = 1
-    @State private var startDate: Date = Date()
+    @State private var useCustomPerDay: Bool = false
+    @State private var customPerDay: [String: Int] = [:]
     @State private var notificationsEnabled: Bool = false
-    @State private var notificationTime: Date = Calendar.current.date(bySettingHour: 8, minute: 0, second: 0, of: Date()) ?? Date()
+    @State private var notificationTimes: [Date] = [
+        Calendar.current.date(bySettingHour: 8, minute: 0, second: 0, of: Date()) ?? Date()
+    ]
+    @State private var page = 0
+
+    private var estimatedCompletion: Date {
+        let plan = ReadingPlan(
+            chaptersPerDay: useCustomPerDay ? nil : chaptersPerDay,
+            chaptersPerDayByDay: useCustomPerDay ? customPerDay : nil,
+            notificationsEnabled: notificationsEnabled,
+            notificationTimeMinutes: (notificationsEnabled && notificationTimes.count == 1) ?
+                PlanCreatorView.dateToMinutes(notificationTimes[0]) : nil,
+            notificationTimesByDay: (notificationsEnabled && notificationTimes.count > 1) ?
+                Dictionary(uniqueKeysWithValues: notificationTimes.enumerated().map { ("t\($0.offset)", PlanCreatorView.dateToMinutes($0.element)) }) : nil,
+            goalType: .chaptersPerDay,
+            preset: .fullBible,
+            nodes: []
+        )
+        return plan.estimatedCompletion
+    }
 
     var body: some View {
         NavigationView {
-            ScrollView {
+            TabView(selection: $page) {
+                // Slide 0: quick settings
                 VStack(spacing: 24) {
                     Text("Welcome to VerseReminder")
                         .font(.largeTitle).bold()
-                        .padding(.top)
-
-                    QuickSettingsPanel()
+                    QuickSettingsPanel(showBiblePicker: false)
                         .environmentObject(authViewModel)
+                }
+                .padding()
+                .tag(0)
 
-                    VStack(alignment: .leading, spacing: 16) {
-                        Text("Bible Version")
-                            .font(.headline)
-                        Picker("Bible", selection: $selectedBible) {
-                            ForEach(bibleOptions, id: .id) { opt in
-                                Text(opt.name).tag(opt.id)
-                            }
+                // Slide 1: bible version
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("Bible Version")
+                        .font(.headline)
+                    Picker("Bible", selection: $selectedBible) {
+                        ForEach(bibleOptions, id: \.id) { opt in
+                            Text(opt.name).tag(opt.id)
                         }
-                        .pickerStyle(.menu)
                     }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding()
-                    .background(
-                        RoundedRectangle(cornerRadius: 16, style: .continuous)
-                            .fill(Color(.secondarySystemBackground))
-                    )
+                    .pickerStyle(.wheel)
+                }
+                .padding()
+                .tag(1)
 
+                // Slide 2: plan and notifications
+                ScrollView {
                     VStack(alignment: .leading, spacing: 16) {
-                        Text("Reading Plan & Notifications")
+                        Text("Reading Plan")
                             .font(.headline)
-                        TextField("Plan Name", text: $planName)
-                            .textFieldStyle(RoundedBorderTextFieldStyle())
+
                         Stepper("Chapters per Day: \(chaptersPerDay)", value: $chaptersPerDay, in: 1...10)
-                        DatePicker("Start Date", selection: $startDate, displayedComponents: .date)
+
+                        Toggle("Customize per-day", isOn: $useCustomPerDay)
+                        if useCustomPerDay {
+                            DayPillarsView(values: $customPerDay, defaultValue: chaptersPerDay)
+                        }
+
+                        Text("Estimated completion: \(estimatedCompletion, style: .date)")
+                            .font(.subheadline)
+
                         Toggle("Enable Notifications", isOn: $notificationsEnabled)
                         if notificationsEnabled {
-                            DatePicker("Notification Time", selection: $notificationTime, displayedComponents: .hourAndMinute)
+                            ForEach(notificationTimes.indices, id: \.self) { idx in
+                                DatePicker("Time \(idx + 1)", selection: $notificationTimes[idx], displayedComponents: .hourAndMinute)
+                            }
+                            Button("Add Time") {
+                                notificationTimes.append(Calendar.current.date(bySettingHour: 8, minute: 0, second: 0, of: Date()) ?? Date())
+                            }
                         }
                     }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding()
-                    .background(
-                        RoundedRectangle(cornerRadius: 16, style: .continuous)
-                            .fill(Color(.secondarySystemBackground))
-                    )
-
-                    Button("Finish") {
-                        authViewModel.updateBibleId(selectedBible)
-                        let plan = ReadingPlan(
-                            name: planName,
-                            startDate: startDate,
-                            chaptersPerDay: chaptersPerDay,
-                            notificationsEnabled: notificationsEnabled,
-                            notificationTimeMinutes: notificationsEnabled ? PlanCreatorView.dateToMinutes(notificationTime) : nil,
-                            goalType: .chaptersPerDay,
-                            preset: .fullBible,
-                            nodes: []
-                        )
-                        authViewModel.setReadingPlan(plan)
-                        authViewModel.saveProfile()
-                        setupComplete = true
-                    }
-                    .buttonStyle(.borderedProminent)
                     .padding(.bottom)
                 }
                 .padding()
+                .tag(2)
             }
-            .navigationTitle("Setup")
+            .tabViewStyle(PageTabViewStyle())
+            .navigationBarTitle("Setup", displayMode: .inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    if page > 0 { Button("Back") { page -= 1 } }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if page < 2 {
+                        Button("Next") { page += 1 }
+                    } else {
+                        Button("Finish") { save() }
+                    }
+                }
+            }
             .onAppear {
                 selectedBible = authViewModel.profile.bibleId
-                planName = authViewModel.profile.readingPlan?.name ?? "My Plan"
                 chaptersPerDay = authViewModel.profile.readingPlan?.chaptersPerDay ?? 1
-                startDate = authViewModel.profile.readingPlan?.startDate ?? Date()
+                customPerDay = authViewModel.profile.readingPlan?.chaptersPerDayByDay ?? [:]
+                useCustomPerDay = !customPerDay.isEmpty
                 notificationsEnabled = authViewModel.profile.readingPlan?.notificationsEnabled ?? false
                 if let mins = authViewModel.profile.readingPlan?.notificationTimeMinutes {
-                    notificationTime = PlanCreatorView.minutesToDate(mins)
+                    notificationTimes = [PlanCreatorView.minutesToDate(mins)]
+                }
+                if let times = authViewModel.profile.readingPlan?.notificationTimesByDay {
+                    notificationTimes = times.keys.sorted().compactMap { key in
+                        if let val = times[key] { return PlanCreatorView.minutesToDate(val) } else { return nil }
+                    }
                 }
             }
         }
+    }
+
+    private func save() {
+        authViewModel.updateBibleId(selectedBible)
+        let plan = ReadingPlan(
+            chaptersPerDay: useCustomPerDay ? nil : chaptersPerDay,
+            chaptersPerDayByDay: useCustomPerDay ? customPerDay : nil,
+            notificationsEnabled: notificationsEnabled,
+            notificationTimeMinutes: (notificationsEnabled && notificationTimes.count == 1) ?
+                PlanCreatorView.dateToMinutes(notificationTimes[0]) : nil,
+            notificationTimesByDay: (notificationsEnabled && notificationTimes.count > 1) ?
+                Dictionary(uniqueKeysWithValues: notificationTimes.enumerated().map { ("t\($0.offset)", PlanCreatorView.dateToMinutes($0.element)) }) : nil,
+            goalType: .chaptersPerDay,
+            preset: .fullBible,
+            nodes: []
+        )
+        authViewModel.setReadingPlan(plan)
+        authViewModel.saveProfile()
+        setupComplete = true
+    }
+}
+
+/// Simple column chart to adjust per-day chapter counts.
+struct DayPillarsView: View {
+    @Binding var values: [String: Int]
+    var defaultValue: Int
+    private let days = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"]
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            ForEach(days, id: \.self) { day in
+                VStack {
+                    Rectangle()
+                        .fill(Color.accentColor.opacity(0.7))
+                        .frame(width: 20, height: CGFloat(values[day] ?? defaultValue) * 12)
+                        .onTapGesture {
+                            let newVal = ((values[day] ?? defaultValue) % 10) + 1
+                            values[day] = newVal
+                        }
+                    Text(String(day.prefix(3)))
+                        .font(.caption2)
+                }
+            }
+        }
+        .animation(.default, value: values)
     }
 }
 

--- a/Views/QuickSettingsPanel.swift
+++ b/Views/QuickSettingsPanel.swift
@@ -3,12 +3,14 @@ import SwiftUI
 struct QuickSettingsPanel: View {
     @EnvironmentObject var authViewModel: AuthViewModel
 
+    var showBiblePicker: Bool = true
+
     private let bibleOptions: [(name: String, id: String)] = [
-        ("DRA", "bible_dra.sqlite"),
-        ("ASV", "bible_asv.sqlite"),
-        ("DBY", "bible_dby.sqlite"),
-        ("KJV", "bible_kjv.sqlite"),
-        ("WYC", "bible_wyc.sqlite")
+        ("Douay-Rheims", "bible_dra.sqlite"),
+        ("American Standard Version", "bible_asv.sqlite"),
+        ("Darby Bible", "bible_dby.sqlite"),
+        ("King James Version", "bible_kjv.sqlite"),
+        ("Wycliffe Bible", "bible_wyc.sqlite")
     ]
 
     @State private var fontSizeValue: Double = 1
@@ -137,7 +139,9 @@ struct QuickSettingsPanel: View {
 
     var body: some View {
         VStack(spacing: 20) {
-            biblePicker
+            if showBiblePicker {
+                biblePicker
+            }
             textSizeSection
             fontStyleSection
             verseSpacingSection


### PR DESCRIPTION
## Summary
- modernize the first time setup flow
- break onboarding into slides for quick settings, bible version, and plan
- include dynamic day pillars and multiple notification times
- allow QuickSettingsPanel to hide the bible picker
- use full Bible names everywhere

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_686b466bb0f0832e88eb9559937e7872