### PR TITLE
Improve setup UI and slider controls

### DIFF
--- a/AppSettings.swift
+++ b/AppSettings.swift
@@ -1,14 +1,9 @@
 import SwiftUI
 
-enum FontSizeOption: String, CaseIterable, Codable {
-    case small, medium, large
-    var pointSize: CGFloat {
-        switch self {
-        case .small: return 14
-        case .medium: return 17
-        case .large: return 20
-        }
-    }
+/// Continuous font size stored as a raw value in points.
+struct FontSizeOption: Codable {
+    var value: Double = 17
+    var pointSize: CGFloat { CGFloat(value) }
 }
 
 enum FontChoice: String, CaseIterable, Codable {
@@ -22,15 +17,10 @@ enum FontChoice: String, CaseIterable, Codable {
     }
 }
 
-enum VerseSpacingOption: String, CaseIterable, Codable {
-    case compact, regular, roomy
-    var spacing: CGFloat {
-        switch self {
-        case .compact: return 4
-        case .regular: return 8
-        case .roomy: return 14
-        }
-    }
+/// Continuous verse spacing stored as a raw value of points between lines.
+struct VerseSpacingOption: Codable {
+    var value: Double = 8
+    var spacing: CGFloat { CGFloat(value) }
 }
 
 enum AppTheme: String, CaseIterable, Codable {

--- a/Models/UserProfile.swift
+++ b/Models/UserProfile.swift
@@ -31,9 +31,9 @@ struct UserProfile {
          chapterNotes: [String: String] = [:],
          verseNotes: [String: [String: String]] = [:],
          bibleId: String = defaultBibleId,
-         fontSize: FontSizeOption = .medium,
+         fontSize: FontSizeOption = FontSizeOption(),
          fontChoice: FontChoice = .system,
-         verseSpacing: VerseSpacingOption = .regular,
+         verseSpacing: VerseSpacingOption = VerseSpacingOption(),
          theme: AppTheme = .light) {
         self.chaptersRead = chaptersRead
         self.chaptersBookmarked = chaptersBookmarked
@@ -67,9 +67,11 @@ extension UserProfile {
         let chapterNotes = dict["chapterNotes"] as? [String: String] ?? [:]
         let verseNotes = dict["verseNotes"] as? [String: [String: String]] ?? [:]
         let bibleId = dict["bibleId"] as? String ?? defaultBibleId
-        let fontSize = FontSizeOption(rawValue: dict["fontSize"] as? String ?? FontSizeOption.medium.rawValue) ?? .medium
+        let fontSizeVal = dict["fontSize"] as? Double ?? 17
+        let fontSize = FontSizeOption(value: fontSizeVal)
         let fontChoice = FontChoice(rawValue: dict["fontChoice"] as? String ?? FontChoice.system.rawValue) ?? .system
-        let verseSpacing = VerseSpacingOption(rawValue: dict["verseSpacing"] as? String ?? VerseSpacingOption.regular.rawValue) ?? .regular
+        let verseSpacingVal = dict["verseSpacing"] as? Double ?? 8
+        let verseSpacing = VerseSpacingOption(value: verseSpacingVal)
         let theme = AppTheme(rawValue: dict["theme"] as? String ?? AppTheme.light.rawValue) ?? .light
         self.init(chaptersRead: chaptersRead, chaptersBookmarked: chaptersBookmarked, lastRead: lastRead, readingPlan: plan, bookmarks: bookmarks, lastReadBookId: lastBook, dailyChapterCounts: dailyCounts, chapterNotes: chapterNotes, verseNotes: verseNotes, bibleId: bibleId, fontSize: fontSize, fontChoice: fontChoice, verseSpacing: verseSpacing, theme: theme)
     }
@@ -84,9 +86,9 @@ extension UserProfile {
             "chapterNotes": chapterNotes,
             "verseNotes": verseNotes,
             "bibleId": bibleId,
-            "fontSize": fontSize.rawValue,
+            "fontSize": fontSize.value,
             "fontChoice": fontChoice.rawValue,
-            "verseSpacing": verseSpacing.rawValue,
+            "verseSpacing": verseSpacing.value,
             "theme": theme.rawValue
         ]
         if let plan = readingPlan {

--- a/Views/QuickSettingsPanel.swift
+++ b/Views/QuickSettingsPanel.swift
@@ -13,36 +13,8 @@ struct QuickSettingsPanel: View {
         ("Wycliffe Bible", "bible_wyc.sqlite")
     ]
 
-    @State private var fontSizeValue: Double = 1
-    @State private var spacingValue: Double = 1
-
-    private func sliderValue(for size: FontSizeOption) -> Double {
-        switch size {
-        case .small: return 0
-        case .medium: return 1
-        case .large: return 2
-        }
-    }
-
-    private func fontSize(for value: Double) -> FontSizeOption {
-        if value < 0.5 { return .small }
-        else if value < 1.5 { return .medium }
-        else { return .large }
-    }
-
-    private func sliderValue(for spacing: VerseSpacingOption) -> Double {
-        switch spacing {
-        case .compact: return 0
-        case .regular: return 1
-        case .roomy: return 2
-        }
-    }
-
-    private func spacingOption(for value: Double) -> VerseSpacingOption {
-        if value < 0.5 { return .compact }
-        else if value < 1.5 { return .regular }
-        else { return .roomy }
-    }
+    @State private var fontSizeValue: Double = 17
+    @State private var spacingValue: Double = 8
 
     private var biblePicker: some View {
         Picker("Bible Version", selection: Binding(
@@ -59,7 +31,7 @@ struct QuickSettingsPanel: View {
         VStack(alignment: .leading) {
             Text("Text Size")
                 .font(.subheadline)
-            Slider(value: $fontSizeValue, in: 0...2, step: 1) {
+            Slider(value: $fontSizeValue, in: 14...24, step: 1) {
                 Text("Text Size")
             } minimumValueLabel: {
                 Text("A").font(.footnote)
@@ -67,7 +39,7 @@ struct QuickSettingsPanel: View {
                 Text("A").font(.title)
             }
             .onChange(of: fontSizeValue) { newValue in
-                authViewModel.updateFontSize(fontSize(for: newValue))
+                authViewModel.updateFontSize(FontSizeOption(value: newValue))
             }
         }
     }
@@ -96,11 +68,11 @@ struct QuickSettingsPanel: View {
         VStack(alignment: .leading) {
             Text("Verse Spacing")
                 .font(.subheadline)
-            Slider(value: $spacingValue, in: 0...2, step: 1) {
+            Slider(value: $spacingValue, in: 4...16, step: 1) {
                 Text("Spacing")
             }
             .onChange(of: spacingValue) { newValue in
-                authViewModel.updateVerseSpacing(spacingOption(for: newValue))
+                authViewModel.updateVerseSpacing(VerseSpacingOption(value: newValue))
             }
         }
     }
@@ -155,8 +127,8 @@ struct QuickSettingsPanel: View {
                 .fill(Color(.secondarySystemBackground))
         )
         .onAppear {
-            fontSizeValue = sliderValue(for: authViewModel.profile.fontSize)
-            spacingValue = sliderValue(for: authViewModel.profile.verseSpacing)
+            fontSizeValue = authViewModel.profile.fontSize.value
+            spacingValue = authViewModel.profile.verseSpacing.value
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow continuous text sizing and verse spacing
- reorder first time setup slides with welcome page
- fade in each setup screen and polish quick settings
- enable deleting notification times
- tweak DayPillarsView for swipe adjustments

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686b4c989448832ea65eaa27af0e839e