### PR TITLE
Adjust setup and plan views

### DIFF
--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -10,6 +10,8 @@ struct ContentView: View {
             TabView(selection: $tabManager.selection) {
                 // Home tab
                 HomeView()
+                    .opacity(tabManager.selection == .home ? 1 : 0)
+                    .animation(.easeInOut(duration: 0.3), value: tabManager.selection)
                     .tabItem {
                         Image(systemName: "house")
                         Text("Home")
@@ -52,6 +54,8 @@ struct ContentView: View {
                     }
                     .environmentObject(booksNavigationManager)
                 }
+                .opacity(tabManager.selection == .books ? 1 : 0)
+                .animation(.easeInOut(duration: 0.3), value: tabManager.selection)
                 .tabItem {
                     Image(systemName: "book.closed")
                     Text("Books")
@@ -59,6 +63,8 @@ struct ContentView: View {
                 .tag(AppTab.books)
 
                 StudyView()
+                    .opacity(tabManager.selection == .study ? 1 : 0)
+                    .animation(.easeInOut(duration: 0.3), value: tabManager.selection)
                     .environmentObject(booksNavigationManager)
                     .tabItem {
                         Image(systemName: "books.vertical")


### PR DESCRIPTION
## Summary
- keep custom per-day planning always on
- center reading plan and Bible version selectors
- color the app name purple in the welcome tab
- show day columns constantly in plan views
- fade between tabs when switching

## Testing
- `swift build` *(fails: Package.swift missing)*
- `swiftformat` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b4e8c2634832ea41caef35b56f395