### PR TITLE
Fix scrolling views respect safe area

### DIFF
--- a/Views/FirstTimeSetupView.swift
+++ b/Views/FirstTimeSetupView.swift
@@ -94,12 +94,9 @@ struct FirstTimeSetupView: View {
                 // Slide 3: plan and notifications
                 ScrollView {
                     GeometryReader { geo in
-                        VStack {
-                            Spacer(minLength: 0)
-
-                            VStack(spacing: 16) {
-                                Text("Reading Plan")
-                                    .font(.headline)
+                        VStack(spacing: 16) {
+                            Text("Reading Plan")
+                                .font(.headline)
 
                             HStack(spacing: 24) {
                                 Button(action: {
@@ -161,10 +158,8 @@ struct FirstTimeSetupView: View {
                         }
                             }
                             .frame(maxWidth: .infinity)
-
-                            Spacer(minLength: 0)
                         }
-                        .frame(minHeight: geo.size.height)
+                        .frame(minHeight: geo.size.height, alignment: .center)
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Views/PlanCreatorView.swift
+++ b/Views/PlanCreatorView.swift
@@ -168,7 +168,6 @@ struct PlanCreatorView: View {
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
             )
-            .ignoresSafeArea()
         )
         .navigationTitle(existingPlan == nil ? "Create Plan" : "Edit Plan")
         .toolbar {


### PR DESCRIPTION
## Summary
- remove `ignoresSafeArea` from `PlanCreatorView` background so the scroll content is not hidden under the nav bar
- center the plan setup page in `FirstTimeSetupView` using the geometry height

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_686bec0fcab8832e9946c77e352e44af