### PR TITLE
Add NIV option and preview to setup

### DIFF
--- a/VerseExtensions.swift
+++ b/VerseExtensions.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension Verse {
+    var verseNumber: String {
+        id.components(separatedBy: ".").last ?? ""
+    }
+
+    var cleanedText: String {
+        let stripped = content.stripHTML().trimmingCharacters(in: .whitespacesAndNewlines)
+        if let num = Int(verseNumber), stripped.hasPrefix("\(num) ") {
+            return String(stripped.dropFirst("\(num) ".count))
+        } else if let num = Int(verseNumber), stripped.hasPrefix("\(num)") {
+            return String(stripped.dropFirst("\(num)".count)).trimmingCharacters(in: .whitespaces)
+        } else {
+            return stripped
+        }
+    }
+}

--- a/Views/QuickSettingsPanel.swift
+++ b/Views/QuickSettingsPanel.swift
@@ -10,7 +10,8 @@ struct QuickSettingsPanel: View {
         ("American Standard Version", "bible_asv.sqlite"),
         ("Darby Bible", "bible_dby.sqlite"),
         ("King James Version", "bible_kjv.sqlite"),
-        ("Wycliffe Bible", "bible_wyc.sqlite")
+        ("Wycliffe Bible", "bible_wyc.sqlite"),
+        ("New International Version", "bible_niv.sqlite")
     ]
 
     @State private var fontSizeValue: Double = 17


### PR DESCRIPTION
## Summary
- extend Bible selection lists with the New International Version
- add preview references and fetch previews during first-time setup
- display fetched preview verses under the Bible picker
- expose `Verse.cleanedText` in a new file

## Testing
- `swiftc -o /tmp/test_compile -emit-executable $(find . -name '*.swift' -print)` *(fails: no such module 'FirebaseFirestore')*

------
https://chatgpt.com/codex/tasks/task_e_686bf06dbf54832ebf67ff1d7c1f97ca