### PR TITLE
Remove duplicate Verse extension

### DIFF
--- a/Views/ChapterView.swift
+++ b/Views/ChapterView.swift
@@ -383,28 +383,6 @@ struct VerseRowView: View {
     }
 }
 
-// MARK: - Verse Extensions
-
-extension Verse {
-    var verseNumber: String {
-        id.components(separatedBy: ".").last ?? ""
-    }
-
-    var cleanedText: String {
-        let stripped = content.stripHTML().trimmingCharacters(in: .whitespacesAndNewlines)
-        // Remove leading number and possible space
-        if let num = Int(verseNumber),
-           stripped.hasPrefix("\(num) ") {
-            return String(stripped.dropFirst("\(num) ".count))
-        } else if let num = Int(verseNumber),
-                  stripped.hasPrefix("\(num)") {
-            return String(stripped.dropFirst("\(num)".count)).trimmingCharacters(in: .whitespaces)
-        } else {
-            return stripped
-        }
-    }
-}
-
 // MARK: - Complete Chapter Toggle
 struct CompleteChapterToggle: View {
     @Binding var isCompleted: Bool


### PR DESCRIPTION
## Summary
- avoid redeclaring `verseNumber` and `cleanedText`
- keep single `Verse` extension in `VerseExtensions.swift`

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686bf240fd74832e851b18f5271f8664