### PR TITLE
Modernize quick settings and onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ attempt again.
 ## Features
 
 - Home screen summarizes your reading progress
-- Quick Settings panel with sliders and live previews for text size, spacing and theme
+- Quick Settings panel with sliders and live previews for text size, spacing and Bible version
 - Browse Bible books and chapters
 - Read verses with an API-based loader
 - Smart search for books, chapters, and verses with fuzzy matching and colored results


### PR DESCRIPTION
## Summary
- move theme selection to its own page in the setup flow
- replace the theme row in `QuickSettingsPanel` with a Bible version picker and remove NIV
- fetch preview text from the selected Bible
- clean up onboarding and docs

## Testing
- `swiftc -parse Views/QuickSettingsPanel.swift`
- `swiftc -parse Views/FirstTimeSetupView.swift`


------
https://chatgpt.com/codex/tasks/task_e_686bf3aaefa8832ea817ca2e9ea1fb39