### PR TITLE
Fix preview load and update theme setup

### DIFF
--- a/Views/FirstTimeSetupView.swift
+++ b/Views/FirstTimeSetupView.swift
@@ -65,14 +65,26 @@ struct FirstTimeSetupView: View {
                 VStack(spacing: 16) {
                     Text("App Theme")
                         .font(.headline)
-                    Picker("Theme", selection: $selectedTheme) {
-                        ForEach(AppTheme.allCases, id: \.self) { theme in
-                            Text(theme.name).tag(theme)
+                    HStack(spacing: 20) {
+                        ForEach([AppTheme.light, AppTheme.dark], id: \.self) { theme in
+                            Button(action: {
+                                selectedTheme = theme
+                                authViewModel.updateTheme(theme)
+                            }) {
+                                VStack {
+                                    Image(systemName: theme == .light ? "sun.max.fill" : "moon.stars.fill")
+                                        .font(.largeTitle)
+                                        .padding(.bottom, 8)
+                                    Text(theme.name)
+                                        .font(.headline)
+                                }
+                                .frame(maxWidth: .infinity, minHeight: 100)
+                                .padding()
+                                .background(selectedTheme == theme ? Color.accentColor.opacity(0.2) : Color(.secondarySystemBackground))
+                                .cornerRadius(12)
+                            }
+                            .buttonStyle(.plain)
                         }
-                    }
-                    .pickerStyle(.wheel)
-                    .onChange(of: selectedTheme) { newTheme in
-                        authViewModel.updateTheme(newTheme)
                     }
                 }
                 .padding()

--- a/Views/QuickSettingsPanel.swift
+++ b/Views/QuickSettingsPanel.swift
@@ -105,7 +105,7 @@ struct QuickSettingsPanel: View {
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .fill(Color(.secondarySystemBackground))
         )
-        .onAppear {
+        .task {
             fontSizeValue = authViewModel.profile.fontSize.value
             spacingValue = authViewModel.profile.verseSpacing.value
             loadPreviewVerse()


### PR DESCRIPTION
## Summary
- ensure the quick settings panel loads its preview verse using a `task`
- simplify theme picker in the first-time setup to two large buttons for Light and Dark

## Testing
- `swiftc -parse Views/QuickSettingsPanel.swift`
- `swiftc -parse Views/FirstTimeSetupView.swift`


------
https://chatgpt.com/codex/tasks/task_e_686bf60958cc832ebb163458dfd7ca33