### PR TITLE
Improve home goal message

### DIFF
--- a/Models/ReadingPlan.swift
+++ b/Models/ReadingPlan.swift
@@ -204,3 +204,34 @@ extension ReadingPlan {
     }
 }
 
+extension ReadingPlan {
+    /// Short textual summary of the reading schedule using three letter day abbreviations.
+    var readingDaysMessage: String {
+        let all = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"]
+        let set = Set(readingDays)
+        let reading = all.filter { set.contains($0) }
+        let skipping = all.filter { !set.contains($0) }
+
+        func list(_ days: [String], plural: Bool, useOr: Bool) -> String {
+            guard !days.isEmpty else { return "" }
+            let names = days.map { plural ? "\($0)s" : $0 }
+            if names.count == 1 {
+                return names[0]
+            } else if names.count == 2 {
+                return names[0] + (useOr ? " or " : " and ") + names[1]
+            } else {
+                let last = names.last!
+                let firstPart = names.dropLast().joined(separator: ", ")
+                return firstPart + ", " + (useOr ? "or " : "and ") + last
+            }
+        }
+
+        if reading.count == 7 {
+            return "Read the bible every day"
+        }
+        let onMsg = "Read the bible on " + list(reading, plural: true, useOr: false)
+        let offMsg = "Read the bible everyday but " + list(skipping, plural: false, useOr: true)
+        return onMsg.count <= offMsg.count ? onMsg : offMsg
+    }
+}
+

--- a/Views/HomeView.swift
+++ b/Views/HomeView.swift
@@ -20,8 +20,8 @@ struct HomeView: View {
 
                             switch plan.goalType {
                             case .chaptersPerDay:
-                                if let custom = plan.chaptersPerDayByDay {
-                                    Text("Goal: variable chapters per day")
+                                if let _ = plan.chaptersPerDayByDay {
+                                    Text(plan.readingDaysMessage)
                                         .font(.subheadline)
                                 } else {
                                     let amount = plan.chaptersPerDay ?? 1


### PR DESCRIPTION
## Summary
- display a concise reading schedule when plans use custom per-day counts
- add helper on `ReadingPlan` for picking the shortest schedule string

## Testing
- `swiftc -parse Views/HomeView.swift Models/ReadingPlan.swift && echo "compiled"`

------
https://chatgpt.com/codex/tasks/task_e_686bfbacc1f0832e8135b30d7386bc80