### PR TITLE
Update plan editor and verse cleanup

### DIFF
--- a/StringExtensions.swift
+++ b/StringExtensions.swift
@@ -25,4 +25,12 @@ extension String {
         let distance = self.levenshteinDistance(to: target)
         return 1 - Double(distance) / Double(max(self.count, target.count))
     }
+
+    /// Removes a leading paragraph symbol if present.
+    func trimmingLeadingParagraphSymbol() -> String {
+        if self.hasPrefix("\u{00B6}") {
+            return String(self.dropFirst()).trimmingCharacters(in: .whitespaces)
+        }
+        return self
+    }
 }

--- a/VerseExtensions.swift
+++ b/VerseExtensions.swift
@@ -6,7 +6,8 @@ extension Verse {
     }
 
     var cleanedText: String {
-        let stripped = content.stripHTML().trimmingCharacters(in: .whitespacesAndNewlines)
+        var stripped = content.stripHTML().trimmingCharacters(in: .whitespacesAndNewlines)
+        stripped = stripped.trimmingLeadingParagraphSymbol()
         if let num = Int(verseNumber), stripped.hasPrefix("\(num) ") {
             return String(stripped.dropFirst("\(num) ".count))
         } else if let num = Int(verseNumber), stripped.hasPrefix("\(num)") {

--- a/Views/PlanCreatorView.swift
+++ b/Views/PlanCreatorView.swift
@@ -109,11 +109,20 @@ struct PlanCreatorView: View {
                 }
 
                 VStack(alignment: .leading) {
-                    HStack {
-                        Text("Chapters per Day: \(chaptersPerDay)")
-                        Slider(value: Binding(get: { Double(min(chaptersPerDay, 20)) }, set: { chaptersPerDay = Int($0) }), in: 1...20, step: 1)
+                    if existingPlan == nil {
+                        HStack {
+                            Text("Chapters per Day: \(chaptersPerDay)")
+                            Slider(
+                                value: Binding(
+                                    get: { Double(min(chaptersPerDay, 20)) },
+                                    set: { chaptersPerDay = Int($0) }
+                                ),
+                                in: 1...20,
+                                step: 1
+                            )
+                        }
+                        .disabled(goalType != .chaptersPerDay)
                     }
-                    .disabled(goalType != .chaptersPerDay)
                     ForEach(allDays, id: \.self) { day in
                         HStack {
                             Text(day)
@@ -207,11 +216,8 @@ struct PlanCreatorView: View {
             }
             if existingPlan != nil {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    Button(role: .destructive) {
-                        authViewModel.deleteReadingPlan()
+                    Button("Close") {
                         dismiss()
-                    } label: {
-                        Text("Delete")
                     }
                 }
             }

--- a/Views/QuickSettingsPanel.swift
+++ b/Views/QuickSettingsPanel.swift
@@ -83,7 +83,7 @@ struct QuickSettingsPanel: View {
         VStack(alignment: .leading) {
             Text("Preview")
                 .font(.subheadline)
-            Text(previewVerse?.content.stripHTML() ?? "Loading...")
+            Text(previewVerse?.content.stripHTML().trimmingLeadingParagraphSymbol() ?? "Loading...")
                 .font(authViewModel.profile.fontChoice.font(size: authViewModel.profile.fontSize.pointSize))
                 .lineSpacing(authViewModel.profile.verseSpacing.spacing)
         }


### PR DESCRIPTION
## Summary
- hide chapter per day slider when editing existing plans
- replace edit plan delete button with a simple close button
- trim leading pilcrow from verse text parsing
- display cleaned preview verse in quick settings

## Testing
- `swiftc -parse StringExtensions.swift VerseExtensions.swift Views/PlanCreatorView.swift Views/QuickSettingsPanel.swift`

------
https://chatgpt.com/codex/tasks/task_e_686bffa08804832ea34032a3e8e4705c