### PR TITLE
Add theme controls to home settings

### DIFF
--- a/Views/HomeSettingsView.swift
+++ b/Views/HomeSettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct HomeSettingsView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
+    @State private var selectedTheme: AppTheme = .light
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -11,6 +12,34 @@ struct HomeSettingsView: View {
 
             QuickSettingsPanel()
                 .environmentObject(authViewModel)
+
+            Text("Theme")
+                .font(.headline)
+
+            HStack(spacing: 20) {
+                ForEach([AppTheme.light, AppTheme.dark], id: \.self) { theme in
+                    Button(action: {
+                        selectedTheme = theme
+                        authViewModel.updateTheme(theme)
+                    }) {
+                        VStack {
+                            Image(systemName: theme == .light ? "sun.max.fill" : "moon.stars.fill")
+                                .font(.largeTitle)
+                                .padding(.bottom, 8)
+                            Text(theme.name)
+                                .font(.headline)
+                        }
+                        .frame(maxWidth: .infinity, minHeight: 100)
+                        .padding()
+                        .background(selectedTheme == theme ? Color.accentColor.opacity(0.2) : Color(.secondarySystemBackground))
+                        .cornerRadius(12)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .onAppear {
+            selectedTheme = authViewModel.profile.theme
         }
         .padding(.top)
     }


### PR DESCRIPTION
## Summary
- add Light and Dark theme picker buttons under quick settings

## Testing
- `swift --version`
- `swiftc Views/HomeSettingsView.swift -o /tmp/out` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686c0193d204832e9ea37d07bc402d62