### PR TITLE
Update study tips & completed goal feedback

### DIFF
--- a/Views/DailyProgressCircle.swift
+++ b/Views/DailyProgressCircle.swift
@@ -6,17 +6,36 @@ struct DailyProgressCircle: View {
         ZStack {
             Circle()
                 .stroke(Color.gray.opacity(0.3), lineWidth: 12)
-            Circle()
-                .trim(from: 0, to: CGFloat(min(progress, 1)))
-                .stroke(
-                    AngularGradient(gradient: Gradient(colors: [Color.green, Color.green.opacity(0.7)]), center: .center),
-                    style: StrokeStyle(lineWidth: 12, lineCap: .round)
-                )
-                .rotationEffect(.degrees(-90))
-                .shadow(color: Color.green.opacity(0.7), radius: 6)
-            Text("\(Int(progress * 100))%")
-                .font(.caption)
-                .bold()
+            if progress >= 1 {
+                Circle()
+                    .trim(from: 0, to: 1)
+                    .stroke(
+                        AngularGradient(gradient: Gradient(colors: [Color.purple, Color.blue]), center: .center),
+                        style: StrokeStyle(lineWidth: 12, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(-90))
+                    .shadow(color: Color.blue.opacity(0.8), radius: 8)
+                Circle()
+                    .fill(
+                        RadialGradient(gradient: Gradient(colors: [Color.blue.opacity(0.3), Color.purple.opacity(0.6)]), center: .center, startRadius: 5, endRadius: 40)
+                    )
+                Text("100%")
+                    .font(.caption)
+                    .bold()
+                    .foregroundColor(.white)
+            } else {
+                Circle()
+                    .trim(from: 0, to: CGFloat(min(progress, 1)))
+                    .stroke(
+                        AngularGradient(gradient: Gradient(colors: [Color.green, Color.green.opacity(0.7)]), center: .center),
+                        style: StrokeStyle(lineWidth: 12, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(-90))
+                    .shadow(color: Color.green.opacity(0.7), radius: 6)
+                Text("\(Int(progress * 100))%")
+                    .font(.caption)
+                    .bold()
+            }
         }
         .frame(width: 80, height: 80)
     }

--- a/Views/HomeView.swift
+++ b/Views/HomeView.swift
@@ -58,9 +58,15 @@ struct HomeView: View {
                                 Text("Today's Progress")
                                     .font(.headline)
                                 DailyProgressCircle(progress: Double(read) / Double(goal))
-                                Text("You've read \(read) of \(goal) chapters today")
-                                    .font(.subheadline)
-                                    .foregroundColor(.secondary)
+                                if read >= goal {
+                                    Text("Today's goal completed!")
+                                        .font(.subheadline)
+                                        .foregroundColor(.purple)
+                                } else {
+                                    Text("You've read \(read) of \(goal) chapters today")
+                                        .font(.subheadline)
+                                        .foregroundColor(.secondary)
+                                }
                                 if read < goal, let last = lastReadReference() {
                                     Button(action: {
                                         let parts = last.ref.split(separator: ".")

--- a/Views/StudyView.swift
+++ b/Views/StudyView.swift
@@ -5,7 +5,6 @@ struct StudyView: View {
     @EnvironmentObject var booksNav: BooksNavigationManager
     @EnvironmentObject var tabManager: TabSelectionManager
     @State private var bookmarkedVerses: [Verse] = []
-    @State private var animateTutorial = false
 
     private var allBooks: [BibleBook] {
         (oldTestamentCategories + newTestamentCategories).flatMap { $0.books }
@@ -22,30 +21,17 @@ struct StudyView: View {
                                 .font(.headline)
                                 .multilineTextAlignment(.center)
                                 .frame(maxWidth: .infinity)
-                            HStack(spacing: 40) {
-                                VStack(spacing: 8) {
-                                    Image(systemName: "bookmark.fill")
-                                        .font(.largeTitle)
-                                        .scaleEffect(animateTutorial ? 1.2 : 1.0)
-                                        .animation(.easeInOut(duration: 1).repeatForever(autoreverses: true), value: animateTutorial)
-                                    Text("Tap the bookmark icon while reading to save verses.")
-                                        .font(.footnote)
-                                        .multilineTextAlignment(.center)
-                                }
-                                VStack(spacing: 8) {
-                                    Image(systemName: "square.and.pencil")
-                                        .font(.largeTitle)
-                                        .scaleEffect(animateTutorial ? 1.2 : 1.0)
-                                        .animation(.easeInOut(duration: 1).repeatForever(autoreverses: true), value: animateTutorial)
-                                    Text("Tap a verse to add a note.")
-                                        .font(.footnote)
-                                        .multilineTextAlignment(.center)
-                                }
+                            VStack(spacing: 8) {
+                                Text("Tap the bookmark icon while reading to save verses.")
+                                    .font(.footnote)
+                                    .multilineTextAlignment(.center)
+                                Text("Tap and hold a verse or click the edit icon in a chapter's header to add a note.")
+                                    .font(.footnote)
+                                    .multilineTextAlignment(.center)
                             }
                         }
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 40)
-                        .onAppear { animateTutorial = true }
                     }
                 }
 


### PR DESCRIPTION
## Summary
- refine the empty state tips in the Study page
- show a message when today's goal is complete
- add a vibrant style to the progress circle once finished

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_686c057e07a0832eaf10af1e519e7ce4