### PR TITLE
Fix dark mode completion toggle

### DIFF
--- a/Views/ChapterView.swift
+++ b/Views/ChapterView.swift
@@ -397,18 +397,18 @@ struct CompleteChapterToggle: View {
         GeometryReader { geo in
             ZStack {
                 Capsule()
-                    .stroke(Color.black, lineWidth: 1)
+                    .stroke(Color.primary, lineWidth: 1)
                     .background(
                         Capsule()
-                            .fill(isCompleted ? Color.black : Color.clear)
+                            .fill(isCompleted ? Color.accentColor : Color.clear)
                     )
 
                 Text(isCompleted ? "Completed" : "Complete Chapter")
-                    .foregroundColor(isCompleted ? .white : .black)
+                    .foregroundColor(isCompleted ? .white : .primary)
                     .frame(maxWidth: .infinity)
 
                 Circle()
-                    .fill(Color.black)
+                    .fill(Color.accentColor)
                     .frame(width: height - 8, height: height - 8)
                     .offset(x: dragOffset - (geo.size.width / 2 - height / 2))
                     .gesture(
@@ -431,7 +431,7 @@ struct CompleteChapterToggle: View {
                             }
                     )
                     .overlay(
-                        Image(systemName: isCompleted ? "checkmark" : "chevron.right")
+                        Image(systemName: "chevron.right")
                             .foregroundColor(.white)
                     )
             }


### PR DESCRIPTION
## Summary
- improve CompleteChapterToggle styling to work in dark theme
- remove checkmark overlay when marked completed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c78feea9c832e80ec157f8dce1dd0