### PR TITLE
Fix book dropdown color in dark mode

### DIFF
--- a/Views/OverviewVIew.swift
+++ b/Views/OverviewVIew.swift
@@ -796,7 +796,7 @@ struct BookDropdownCell: View {
                     .padding(.bottom, 14)
                     .background(
                         RoundedRectangle(cornerRadius: 20)
-                            .fill(Color(.systemBackground))
+                            .fill(Color(.secondarySystemBackground))
                             .shadow(color: Color.black.opacity(0.08), radius: 6, y: 2)
                     )
                     .opacity(showContent ? 1 : 0)


### PR DESCRIPTION
## Summary
- match dropdown background with list color in dark mode

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_686c7f9f775c832e86515f4321efd480