### PR TITLE
Add advanced settings and info pages

### DIFF
--- a/Models/UserDataStore.swift
+++ b/Models/UserDataStore.swift
@@ -19,4 +19,10 @@ class UserDataStore {
             }
         }
     }
+
+    func deleteProfile(uid: String, completion: ((Error?) -> Void)? = nil) {
+        db.collection("users").document(uid).delete { error in
+            completion?(error)
+        }
+    }
 }

--- a/ViewModels/AuthViewModel.swift
+++ b/ViewModels/AuthViewModel.swift
@@ -251,5 +251,13 @@ class AuthViewModel: ObservableObject {
         UserDefaults.standard.set(false, forKey: "setupComplete")
     }
 
+    /// Permanently remove stored user data from Firestore and reset locally.
+    func deleteAccount() {
+        guard let uid = user?.uid else { return }
+        dataStore.deleteProfile(uid: uid) { _ in }
+        profile = UserProfile()
+        UserDefaults.standard.set(false, forKey: "setupComplete")
+    }
+
 }
 

--- a/Views/AdvancedSettingsView.swift
+++ b/Views/AdvancedSettingsView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct AdvancedSettingsView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @State private var showReset = false
+    @State private var showDelete = false
+
+    var body: some View {
+        List {
+            Section {
+                Button("Reset Account") { showReset = true }
+                    .frame(maxWidth: .infinity, alignment: .center)
+                Button(role: .destructive) { showDelete = true } label: {
+                    Text("Delete Account")
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+                Text("Both options reset your progress. Delete Account also removes all your data from our servers.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                    .padding(.top, 4)
+            }
+        }
+        .navigationTitle("Advanced Settings")
+        .sheet(isPresented: $showReset) {
+            ResetAccountView()
+                .environmentObject(authViewModel)
+        }
+        .sheet(isPresented: $showDelete) {
+            DeleteAccountView()
+                .environmentObject(authViewModel)
+        }
+    }
+}

--- a/Views/ContactView.swift
+++ b/Views/ContactView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct ContactView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "envelope.fill")
+                .font(.system(size: 40))
+                .padding(.bottom, 8)
+            Text("Email us at")
+            Link("support@example.com", destination: URL(string: "mailto:support@example.com")!)
+                .foregroundColor(.blue)
+        }
+        .navigationTitle("Contact Us")
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}

--- a/Views/DeleteAccountView.swift
+++ b/Views/DeleteAccountView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct DeleteAccountView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var text = ""
+
+    private var isConfirmed: Bool {
+        text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "delete"
+    }
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Type \"DELETE\" to remove your account data from our servers. This cannot be undone.")
+                .multilineTextAlignment(.center)
+            TextField("DELETE", text: $text)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .autocapitalization(.none)
+                .padding(.horizontal)
+            if isConfirmed {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.largeTitle)
+                    .foregroundColor(.green)
+                    .transition(.scale)
+            }
+            Button(role: .destructive) {
+                authViewModel.deleteAccount()
+                dismiss()
+            } label: {
+                Text("Delete Account")
+            }
+            .disabled(!isConfirmed)
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+}

--- a/Views/HomeView.swift
+++ b/Views/HomeView.swift
@@ -8,6 +8,9 @@ struct HomeView: View {
     @State private var showPlanCreator = false
     @State private var editingPlan: ReadingPlan? = nil
     @State private var showReset = false
+    @State private var showAdvanced = false
+    @State private var showContact = false
+    @State private var showPrivacy = false
 
     var body: some View {
         NavigationView {
@@ -114,6 +117,19 @@ struct HomeView: View {
                 .padding()
             }
             .navigationTitle("Home")
+            .toolbar {
+                ToolbarItemGroup(placement: .navigationBarTrailing) {
+                    Button { showPrivacy = true } label: {
+                        Image(systemName: "lock.shield")
+                    }
+                    Button { showContact = true } label: {
+                        Image(systemName: "envelope")
+                    }
+                    Button { showAdvanced = true } label: {
+                        Image(systemName: "gearshape")
+                    }
+                }
+            }
             .sheet(isPresented: $showPlanCreator) {
                 NavigationView { PlanCreatorView() }
             }
@@ -123,6 +139,16 @@ struct HomeView: View {
             .sheet(isPresented: $showReset) {
                 ResetAccountView()
                     .environmentObject(authViewModel)
+            }
+            .sheet(isPresented: $showAdvanced) {
+                NavigationView { AdvancedSettingsView() }
+                    .environmentObject(authViewModel)
+            }
+            .sheet(isPresented: $showContact) {
+                NavigationView { ContactView() }
+            }
+            .sheet(isPresented: $showPrivacy) {
+                NavigationView { PrivacyPolicyView() }
             }
         }
     }

--- a/Views/PrivacyPolicyView.swift
+++ b/Views/PrivacyPolicyView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct PrivacyPolicyView: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Image(systemName: "lock.shield.fill")
+                    .font(.system(size: 40))
+                    .padding(.bottom, 8)
+                    .frame(maxWidth: .infinity)
+                Text("Privacy Policy")
+                    .font(.title2)
+                Text("We respect your privacy and only store data necessary for your progress tracking.")
+                Link("Read full policy", destination: URL(string: "https://example.com/privacy")!)
+                    .foregroundColor(.blue)
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .navigationTitle("Privacy Policy")
+    }
+}


### PR DESCRIPTION
## Summary
- add ability to delete profile from `UserDataStore`
- expose `deleteAccount()` in `AuthViewModel`
- integrate advanced settings, contact and privacy policy sheets on home screen
- implement `AdvancedSettingsView` and `DeleteAccountView` with typed confirmation
- add simple `ContactView` and `PrivacyPolicyView`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_686c82f74c40832e965c46f9f8482548