### PR TITLE
Move links below theme selector

### DIFF
--- a/Views/HomeSettingsView.swift
+++ b/Views/HomeSettingsView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 struct HomeSettingsView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
+    @Binding var showAdvanced: Bool
+    @Binding var showContact: Bool
+    @Binding var showPrivacy: Bool
     @State private var selectedTheme: AppTheme = .light
     @State private var themeCheckTask: DispatchWorkItem?
 
@@ -38,6 +41,42 @@ struct HomeSettingsView: View {
                     .buttonStyle(.plain)
                 }
             }
+
+            HStack(spacing: 40) {
+                Button { showPrivacy = true } label: {
+                    VStack {
+                        Image(systemName: "lock.shield")
+                            .font(.title2)
+                        Text("Privacy Policy")
+                            .font(.footnote)
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.plain)
+
+                Button { showContact = true } label: {
+                    VStack {
+                        Image(systemName: "envelope")
+                            .font(.title2)
+                        Text("Contact Us")
+                            .font(.footnote)
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.plain)
+
+                Button { showAdvanced = true } label: {
+                    VStack {
+                        Image(systemName: "gearshape")
+                            .font(.title2)
+                        Text("Settings")
+                            .font(.footnote)
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.top, 8)
         }
         .onAppear {
             themeCheckTask?.cancel()

--- a/Views/HomeView.swift
+++ b/Views/HomeView.swift
@@ -103,7 +103,7 @@ struct HomeView: View {
                                 .cornerRadius(12)
                         }
                     }
-                    HomeSettingsView()
+                    HomeSettingsView(showAdvanced: $showAdvanced, showContact: $showContact, showPrivacy: $showPrivacy)
                     DonateSectionView()
                     Button(role: .destructive) {
                         showReset = true
@@ -117,19 +117,6 @@ struct HomeView: View {
                 .padding()
             }
             .navigationTitle("Home")
-            .toolbar {
-                ToolbarItemGroup(placement: .navigationBarTrailing) {
-                    Button { showPrivacy = true } label: {
-                        Image(systemName: "lock.shield")
-                    }
-                    Button { showContact = true } label: {
-                        Image(systemName: "envelope")
-                    }
-                    Button { showAdvanced = true } label: {
-                        Image(systemName: "gearshape")
-                    }
-                }
-            }
             .sheet(isPresented: $showPlanCreator) {
                 NavigationView { PlanCreatorView() }
             }


### PR DESCRIPTION
## Summary
- show privacy policy, contact and advanced settings buttons in HomeSettingsView
- drop header toolbar buttons

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686c84c75844832ebd784271faae5853