### PR TITLE
Add contact form with DB integration

### DIFF
--- a/Networking/ContactAPI.swift
+++ b/Networking/ContactAPI.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+enum ContactAPIError: Error {
+    case requestFailed
+    case invalidResponse
+}
+
+class ContactAPI {
+    static let shared = ContactAPI()
+    private init() {}
+
+    private let baseUrl = "https://usa-chat.com"
+    private let userId = "local-admin"
+    private let password = "supersecret"
+
+    private func request(path: String, method: String = "POST", body: [String: Any]? = nil, completion: @escaping (Result<Data, ContactAPIError>) -> Void) {
+        guard let url = URL(string: baseUrl + path) else {
+            completion(.failure(.requestFailed))
+            return
+        }
+        var req = URLRequest(url: url)
+        req.httpMethod = method
+        if method == "POST" { req.addValue("application/json", forHTTPHeaderField: "Content-Type") }
+        req.addValue(password, forHTTPHeaderField: "x-central-password")
+        if let body = body {
+            req.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        }
+        URLSession.shared.dataTask(with: req) { data, resp, err in
+            if let data = data, err == nil {
+                completion(.success(data))
+            } else {
+                completion(.failure(.requestFailed))
+            }
+        }.resume()
+    }
+
+    private func ensureSchema(completion: @escaping () -> Void) {
+        guard let url = URL(string: "\(baseUrl)/db/column_info?user_id=\(userId)&db_file=contact.sqlite&table=messages") else {
+            completion(); return
+        }
+        var req = URLRequest(url: url)
+        req.addValue(password, forHTTPHeaderField: "x-central-password")
+        URLSession.shared.dataTask(with: req) { data, _, _ in
+            var hasColumn = false
+            if let data = data,
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let cols = json["columns"] as? [[String: Any]] {
+                hasColumn = cols.contains { ($0["name"] as? String) == "created_at" }
+            }
+            if !hasColumn {
+                let sql = "ALTER TABLE messages ADD COLUMN created_at TEXT"
+                self.request(path: "/db/exec", body: [
+                    "user_id": self.userId,
+                    "db_file": "contact.sqlite",
+                    "sql": sql
+                ]) { _ in completion() }
+            } else {
+                completion()
+            }
+        }.resume()
+    }
+
+    func submitMessage(email: String, name: String, message: String, completion: @escaping (Result<Void, ContactAPIError>) -> Void) {
+        ensureSchema {
+            let timestamp = ISO8601DateFormatter().string(from: Date())
+            let body: [String: Any] = [
+                "user_id": self.userId,
+                "db_file": "contact.sqlite",
+                "table": "messages",
+                "row": [
+                    "email": email,
+                    "name": name,
+                    "message": message,
+                    "created_at": timestamp
+                ]
+            ]
+            self.request(path: "/db/insert_row", body: body) { result in
+                switch result {
+                case .success:
+                    completion(.success(()))
+                case .failure:
+                    completion(.failure(.requestFailed))
+                }
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ attempt again.
 - Reading plans are non-linear by default and can be built from presets such as the full Bible, Old or New Testament, Gospels, Prophets, and more
 - Each plan stores a progress tree so completion can be computed from your reading history
 - Edit your reading plan anytime from the Home tab
+- Contact Us form to reach the developer

--- a/Views/ContactView.swift
+++ b/Views/ContactView.swift
@@ -1,17 +1,59 @@
 import SwiftUI
 
 struct ContactView: View {
+    @State private var email = ""
+    @State private var name = ""
+    @State private var message = ""
+    @State private var isSubmitting = false
+    @State private var resultMessage: String?
+
     var body: some View {
-        VStack(spacing: 16) {
-            Image(systemName: "envelope.fill")
-                .font(.system(size: 40))
-                .padding(.bottom, 8)
-            Text("Email us at")
-            Link("support@example.com", destination: URL(string: "mailto:support@example.com")!)
-                .foregroundColor(.blue)
+        Form {
+            Section(header: Text("Your Info")) {
+                TextField("Name", text: $name)
+                    .textInputAutocapitalization(.words)
+                TextField("Email", text: $email)
+                    .keyboardType(.emailAddress)
+                    .autocapitalization(.none)
+            }
+            Section(header: Text("Message")) {
+                TextEditor(text: $message)
+                    .frame(minHeight: 150)
+            }
+            Section {
+                if let result = resultMessage {
+                    Text(result)
+                        .foregroundColor(.secondary)
+                }
+                Button(action: submit) {
+                    if isSubmitting {
+                        ProgressView()
+                    } else {
+                        Text("Send")
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+                .disabled(isSubmitting || email.isEmpty || message.isEmpty)
+            }
         }
         .navigationTitle("Contact Us")
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding()
+    }
+
+    private func submit() {
+        isSubmitting = true
+        ContactAPI.shared.submitMessage(email: email, name: name, message: message) { result in
+            DispatchQueue.main.async {
+                isSubmitting = false
+                switch result {
+                case .success:
+                    resultMessage = "Thank you! Your message was sent."
+                    email = ""
+                    name = ""
+                    message = ""
+                case .failure:
+                    resultMessage = "Failed to send message. Please try again later."
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement `ContactAPI` for sending contact messages
- add a `created_at` column to the remote messages table
- overhaul `ContactView` into an interactive contact form
- mention the contact form in the README

## Testing
- `swiftc -parse Networking/ContactAPI.swift Views/ContactView.swift`

------
https://chatgpt.com/codex/tasks/task_e_686c8b8f4d58832ea44f09832a563566