### PR TITLE
Add test notification button

### DIFF
--- a/NotificationManager.swift
+++ b/NotificationManager.swift
@@ -84,4 +84,22 @@ struct NotificationManager {
             }
         }
     }
+
+    /// Schedule a quick notification used for manual testing.
+    func scheduleTestNotification() {
+        requestAuthorizationIfNeeded()
+        let content = UNMutableNotificationContent()
+        content.title = "Test Notification"
+        content.body = "This is a test of the notification system."
+        content.sound = .default
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false)
+        let id = "test-\(UUID().uuidString)"
+        let request = UNNotificationRequest(identifier: id, content: content, trigger: trigger)
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error = error {
+                print("Failed to schedule test notification: \(error)")
+            }
+        }
+    }
 }

--- a/Views/DonateSectionView.swift
+++ b/Views/DonateSectionView.swift
@@ -6,6 +6,10 @@ struct DonateSectionView: View {
             Text("If you have enjoyed or received value from this app, consider supporting my projects here:")
             Link("buymeacoffee.com/jonathanhori", destination: URL(string: "https://buymeacoffee.com/jonathanhori")!)
                 .foregroundColor(.blue)
+            Button("Send Test Notification") {
+                NotificationManager.shared.scheduleTestNotification()
+            }
+            .foregroundColor(.blue)
         }
         .font(.footnote)
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- enable manual notification testing by adding a button
- implement helper to schedule a quick test notification

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_686d2aa36794832e9503b3fbe39397b1