### PR TITLE
Remove test notification button

### DIFF
--- a/Views/DonateSectionView.swift
+++ b/Views/DonateSectionView.swift
@@ -6,10 +6,6 @@ struct DonateSectionView: View {
             Text("If you have enjoyed or received value from this app, consider supporting my projects here:")
             Link("buymeacoffee.com/jonathanhori", destination: URL(string: "https://buymeacoffee.com/jonathanhori")!)
                 .foregroundColor(.blue)
-            Button("Send Test Notification") {
-                NotificationManager.shared.scheduleTestNotification()
-            }
-            .foregroundColor(.blue)
         }
         .font(.footnote)
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- remove the temporary "Send Test Notification" button from DonateSectionView

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686d2eeb780c832e8decc76b9ca17c13