### PR TITLE
Fix snapshot test build errors

### DIFF
--- a/Verse ReminderUITests/FastlaneSnapshotTests.swift
+++ b/Verse ReminderUITests/FastlaneSnapshotTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 
+@MainActor
 final class FastlaneSnapshotTests: XCTestCase {
     private var app: XCUIApplication!
 


### PR DESCRIPTION
## Summary
- fix concurrency error by adding `@MainActor` to `FastlaneSnapshotTests`

## Testing
- `bundle install`
- `bundle exec fastlane screenshots` *(fails: uninitialized constant FastlaneCore::UpdateChecker)*

------
https://chatgpt.com/codex/tasks/task_e_686eb7f328b8832e90f3aa9e881fe0e4