### PR TITLE
Fix root VC lookup for Google sign-in

### DIFF
--- a/Verse Reminder/ViewModels/AuthViewModel.swift
+++ b/Verse Reminder/ViewModels/AuthViewModel.swift
@@ -70,7 +70,10 @@ class AuthViewModel: ObservableObject {
     }
 
     func linkWithGoogle(completion: @escaping (Error?) -> Void) {
-        guard let topVC = UIApplication.shared.windows.first?.rootViewController else {
+        let scenes = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+        let rootVC = scenes.first?.windows.first?.rootViewController
+        guard let topVC = rootVC else {
             completion(NSError(domain: "UI", code: -1, userInfo: [NSLocalizedDescriptionKey: "No Root VC"]))
             return
         }


### PR DESCRIPTION
## Summary
- update `linkWithGoogle` to determine the root view controller using `connectedScenes`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f25d22384832eb2ad508a6410ee2d