### PR TITLE
Improve fastlane snapshot setup

### DIFF
--- a/Verse Reminder/Verse_ReminderApp.swift
+++ b/Verse Reminder/Verse_ReminderApp.swift
@@ -14,6 +14,12 @@ struct Verse_ReminderApp: App {
 
     init() {
         FirebaseApp.configure()
+
+        if CommandLine.arguments.contains("--fastlane-snapshot") ||
+            ProcessInfo.processInfo.environment["FASTLANE_SNAPSHOT"] == "YES" {
+            UserDefaults.standard.set(true, forKey: "setupComplete")
+        }
+
         _authViewModel = StateObject(wrappedValue: AuthViewModel())
     }
 

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -1,0 +1,12 @@
+# Sample Snapfile for capturing screenshots
+scheme "Verse Reminder"
+
+# Devices to run snapshot on
+devices([
+  "iPhone 14",
+  "iPad Pro (12.9-inch) (6th generation)"
+])
+
+languages(["en-US"])
+
+clear_previous_screenshots(true)


### PR DESCRIPTION
## Summary
- skip first-time setup when launching with `--fastlane-snapshot`
- add a `Snapfile` defining devices including iPad

## Testing
- `bundle install`
- `bundle exec fastlane ios screenshots` *(fails: uninitialized constant FastlaneCore::UpdateChecker)*

------
https://chatgpt.com/codex/tasks/task_e_68702d8c88d8832ea0474812663b42ad