### PR TITLE
Set dark mode as default and adjust snapshots

### DIFF
--- a/Verse Reminder/Models/UserProfile.swift
+++ b/Verse Reminder/Models/UserProfile.swift
@@ -33,8 +33,8 @@ struct UserProfile {
          bibleId: String = defaultBibleId,
          fontSize: FontSizeOption = FontSizeOption(),
          fontChoice: FontChoice = .system,
-         verseSpacing: VerseSpacingOption = VerseSpacingOption(),
-         theme: AppTheme = .light) {
+        verseSpacing: VerseSpacingOption = VerseSpacingOption(),
+        theme: AppTheme = .dark) {
         self.chaptersRead = chaptersRead
         self.chaptersBookmarked = chaptersBookmarked
         self.lastRead = lastRead
@@ -72,7 +72,7 @@ extension UserProfile {
         let fontChoice = FontChoice(rawValue: dict["fontChoice"] as? String ?? FontChoice.system.rawValue) ?? .system
         let verseSpacingVal = dict["verseSpacing"] as? Double ?? 8
         let verseSpacing = VerseSpacingOption(value: verseSpacingVal)
-        let theme = AppTheme(rawValue: dict["theme"] as? String ?? AppTheme.light.rawValue) ?? .light
+        let theme = AppTheme(rawValue: dict["theme"] as? String ?? AppTheme.dark.rawValue) ?? .dark
         self.init(chaptersRead: chaptersRead, chaptersBookmarked: chaptersBookmarked, lastRead: lastRead, readingPlan: plan, bookmarks: bookmarks, lastReadBookId: lastBook, dailyChapterCounts: dailyCounts, chapterNotes: chapterNotes, verseNotes: verseNotes, bibleId: bibleId, fontSize: fontSize, fontChoice: fontChoice, verseSpacing: verseSpacing, theme: theme)
     }
 

--- a/Verse Reminder/Views/FirstTimeSetupView.swift
+++ b/Verse Reminder/Views/FirstTimeSetupView.swift
@@ -16,7 +16,7 @@ struct FirstTimeSetupView: View {
     private let allDays = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"]
 
     @State private var selectedBible: String = defaultBibleId
-    @State private var selectedTheme: AppTheme = .light
+    @State private var selectedTheme: AppTheme = .dark
     @State private var chaptersPerDay: Int = 1
     @State private var customPerDay: [String: Int] = [:]
     @State private var notificationsEnabled: Bool = false

--- a/Verse Reminder/Views/HomeSettingsView.swift
+++ b/Verse Reminder/Views/HomeSettingsView.swift
@@ -5,7 +5,7 @@ struct HomeSettingsView: View {
     @Binding var showAdvanced: Bool
     @Binding var showContact: Bool
     @Binding var showPrivacy: Bool
-    @State private var selectedTheme: AppTheme = .light
+    @State private var selectedTheme: AppTheme = .dark
     @State private var themeCheckTask: DispatchWorkItem?
 
     var body: some View {

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -18,4 +18,6 @@ devices([
 
 languages(["en-US"])
 
+user_interface_style("dark")
+
 clear_previous_screenshots(true)


### PR DESCRIPTION
## Summary
- default app theme is now Dark
- apply dark mode setting for fastlane screenshots
- update theme selection defaults

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68703192e110832ea8888dab158a5105