### PR TITLE
Implement iPad UI and enforce setup flow

### DIFF
--- a/Verse Reminder/Views/ContentView.swift
+++ b/Verse Reminder/Views/ContentView.swift
@@ -4,56 +4,29 @@ struct ContentView: View {
     @StateObject private var booksNavigationManager = BooksNavigationManager()
     @StateObject private var tabManager = TabSelectionManager()
     @EnvironmentObject var authViewModel: AuthViewModel
+    @Environment(\.horizontalSizeClass) private var sizeClass
 
     var body: some View {
-        ZStack {
-            TabView(selection: $tabManager.selection) {
-                // Home tab
-                HomeView()
-                    .opacity(tabManager.selection == .home ? 1 : 0)
-                    .animation(.easeInOut(duration: 0.3), value: tabManager.selection)
-                    .tabItem {
-                        Image(systemName: "house")
-                        Text("Home")
-                    }
-                    .tag(AppTab.home)
+        if sizeClass == .regular {
+            iPadBody
+        } else {
+            iPhoneBody
+        }
+    }
 
-                // "Books" tab: the main Bible navigation/reading UI
-                NavigationView {
-                    NavigationStack(path: $booksNavigationManager.path) {
-                        VStack(spacing: 0) {
-                            OverviewView()
-                        }
-                        .navigationDestination(for: BooksRoute.self) { route in
-                            switch route {
-                            case .expandedBook(let id):
-                                if let book = (oldTestamentCategories + newTestamentCategories)
-                                    .flatMap({ $0.books })
-                                    .first(where: { $0.id == id }) {
-                                    ExpandedBookView(
-                                        book: book,
-                                        searchManager: BibleSearchManager(),
-                                        chaptersRead: authViewModel.profile.chaptersRead.mapValues { Set($0) },
-                                        chaptersBookmarked: authViewModel.profile.chaptersBookmarked.mapValues { Set($0) },
-                                        lastRead: authViewModel.profile.lastRead.reduce(into: [String: (chapter: Int, verse: Int)]()) { partial, item in
-                                            partial[item.key] = (item.value["chapter"] ?? 1, item.value["verse"] ?? 0)
-                                        }
-                                    ) { b, chapter in
-                                        booksNavigationManager.path.append(
-                                            BooksRoute.chapter(bookId: b.id, chapter: chapter, highlight: nil))
-                                    }
-                                }
-                            case .chapter(let bid, let chap, let highlight):
-                                ChapterView(
-                                    chapterId: "\(bid).\(chap)",
-                                    bibleId: authViewModel.profile.bibleId,
-                                    highlightVerse: highlight
-                                )
-                            }
-                        }
-                    }
-                    .environmentObject(booksNavigationManager)
+    // MARK: - Phone Layout
+    private var iPhoneBody: some View {
+        TabView(selection: $tabManager.selection) {
+            HomeView()
+                .opacity(tabManager.selection == .home ? 1 : 0)
+                .animation(.easeInOut(duration: 0.3), value: tabManager.selection)
+                .tabItem {
+                    Image(systemName: "house")
+                    Text("Home")
                 }
+                .tag(AppTab.home)
+
+            NavigationView { booksStack }
                 .opacity(tabManager.selection == .books ? 1 : 0)
                 .animation(.easeInOut(duration: 0.3), value: tabManager.selection)
                 .tabItem {
@@ -62,19 +35,78 @@ struct ContentView: View {
                 }
                 .tag(AppTab.books)
 
-                StudyView()
-                    .opacity(tabManager.selection == .study ? 1 : 0)
-                    .animation(.easeInOut(duration: 0.3), value: tabManager.selection)
-                    .environmentObject(booksNavigationManager)
-                    .tabItem {
-                        Image(systemName: "books.vertical")
-                        Text("Study")
-                    }
-                    .tag(AppTab.study)
-            }
-            .environmentObject(booksNavigationManager)
-            .environmentObject(tabManager)
+            StudyView()
+                .opacity(tabManager.selection == .study ? 1 : 0)
+                .animation(.easeInOut(duration: 0.3), value: tabManager.selection)
+                .environmentObject(booksNavigationManager)
+                .tabItem {
+                    Image(systemName: "books.vertical")
+                    Text("Study")
+                }
+                .tag(AppTab.study)
+        }
+        .environmentObject(booksNavigationManager)
+        .environmentObject(tabManager)
+    }
 
+    // MARK: - iPad Layout
+    private var iPadBody: some View {
+        NavigationSplitView {
+            List(selection: $tabManager.selection) {
+                Label("Home", systemImage: "house").tag(AppTab.home)
+                Label("Books", systemImage: "book.closed").tag(AppTab.books)
+                Label("Study", systemImage: "books.vertical").tag(AppTab.study)
+            }
+            .navigationTitle("VerseReminder")
+            .listStyle(.sidebar)
+        } detail: {
+            switch tabManager.selection {
+            case .home:
+                HomeView()
+            case .books:
+                booksStack
+            case .study:
+                StudyView()
+            }
+        }
+        .environmentObject(booksNavigationManager)
+        .environmentObject(tabManager)
+    }
+
+    // MARK: - Shared Books Navigation
+    @ViewBuilder
+    private var booksStack: some View {
+        NavigationStack(path: $booksNavigationManager.path) {
+            VStack(spacing: 0) {
+                OverviewView()
+            }
+            .navigationDestination(for: BooksRoute.self) { route in
+                switch route {
+                case .expandedBook(let id):
+                    if let book = (oldTestamentCategories + newTestamentCategories)
+                        .flatMap({ $0.books })
+                        .first(where: { $0.id == id }) {
+                        ExpandedBookView(
+                            book: book,
+                            searchManager: BibleSearchManager(),
+                            chaptersRead: authViewModel.profile.chaptersRead.mapValues { Set($0) },
+                            chaptersBookmarked: authViewModel.profile.chaptersBookmarked.mapValues { Set($0) },
+                            lastRead: authViewModel.profile.lastRead.reduce(into: [String: (chapter: Int, verse: Int)]()) { partial, item in
+                                partial[item.key] = (item.value["chapter"] ?? 1, item.value["verse"] ?? 0)
+                            }
+                        ) { b, chapter in
+                            booksNavigationManager.path.append(
+                                BooksRoute.chapter(bookId: b.id, chapter: chapter, highlight: nil))
+                        }
+                    }
+                case .chapter(let bid, let chap, let highlight):
+                    ChapterView(
+                        chapterId: "\(bid).\(chap)",
+                        bibleId: authViewModel.profile.bibleId,
+                        highlightVerse: highlight
+                    )
+                }
+            }
         }
     }
 }

--- a/Verse Reminder/Views/HomeView.swift
+++ b/Verse Reminder/Views/HomeView.swift
@@ -92,16 +92,6 @@ struct HomeView: View {
                             .frame(maxWidth: .infinity)
                         }
                     }
-                    } else {
-                        VStack(spacing: 16) {
-                            Text("No reading plan yet")
-                                .font(.title2)
-                            Button("Create Plan") { showPlanCreator = true }
-                                .padding()
-                                .background(Color.blue)
-                                .foregroundColor(.white)
-                                .cornerRadius(12)
-                        }
                     }
                     HomeSettingsView(showAdvanced: $showAdvanced, showContact: $showContact, showPrivacy: $showPrivacy)
                     DonateSectionView()

--- a/Verse Reminder/Views/RootView.swift
+++ b/Verse Reminder/Views/RootView.swift
@@ -10,7 +10,7 @@ struct RootView: View {
             if authViewModel.isLoading {
                 ProgressView()
             } else if authViewModel.user != nil {
-                if setupComplete {
+                if setupComplete && authViewModel.profile.readingPlan != nil {
                     ContentView()
                 } else {
                     FirstTimeSetupView()


### PR DESCRIPTION
## Summary
- ensure the app enters first time setup if no plan exists
- remove the unused "Create Plan" state from HomeView
- redesign ContentView with a split view on iPad while keeping phone tabs

## Testing
- `bundle install`
- `bundle exec fastlane screenshots` *(fails: uninitialized constant FastlaneCore::UpdateChecker)*

------
https://chatgpt.com/codex/tasks/task_e_687037ad5488832eb618fa91f4d1cbdb