### PR TITLE
Fix iPad layout to use full-screen navigation

### DIFF
--- a/Verse Reminder/Views/BookmarksView.swift
+++ b/Verse Reminder/Views/BookmarksView.swift
@@ -37,6 +37,7 @@ struct BookmarksView: View {
             }
             .onAppear(perform: loadVerses)
         }
+        .navigationViewStyle(.stack)
     }
 
     private func referencePrefix(for id: String) -> String {

--- a/Verse Reminder/Views/ContentView.swift
+++ b/Verse Reminder/Views/ContentView.swift
@@ -4,18 +4,12 @@ struct ContentView: View {
     @StateObject private var booksNavigationManager = BooksNavigationManager()
     @StateObject private var tabManager = TabSelectionManager()
     @EnvironmentObject var authViewModel: AuthViewModel
-    @Environment(\.horizontalSizeClass) private var sizeClass
-
     var body: some View {
-        if sizeClass == .regular {
-            iPadBody
-        } else {
-            iPhoneBody
-        }
+        tabBody
     }
 
-    // MARK: - Phone Layout
-    private var iPhoneBody: some View {
+    // MARK: - Shared Layout
+    private var tabBody: some View {
         TabView(selection: $tabManager.selection) {
             HomeView()
                 .opacity(tabManager.selection == .home ? 1 : 0)
@@ -47,45 +41,6 @@ struct ContentView: View {
         }
         .environmentObject(booksNavigationManager)
         .environmentObject(tabManager)
-    }
-
-    // MARK: - iPad Layout
-    private var iPadBody: some View {
-        NavigationSplitView {
-            List {
-                sidebarRow(tab: .home)
-                sidebarRow(tab: .books)
-                sidebarRow(tab: .study)
-            }
-            .navigationTitle("VerseReminder")
-            .listStyle(.sidebar)
-        } detail: {
-            switch tabManager.selection {
-            case .home:
-                HomeView()
-            case .books:
-                booksStack
-            case .study:
-                StudyView()
-            }
-        }
-        .environmentObject(booksNavigationManager)
-        .environmentObject(tabManager)
-    }
-
-    // MARK: - Sidebar Row Helper
-    @ViewBuilder
-    private func sidebarRow(tab: AppTab) -> some View {
-        let selected = tabManager.selection == tab
-        Button(action: {
-            tabManager.selection = tab
-        }) {
-            Label(tab.title, systemImage: tab.icon)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .foregroundColor(selected ? .accentColor : .primary)
-                .background(selected ? Color.accentColor.opacity(0.12) : Color.clear)
-        }
-        .buttonStyle(.plain)
     }
 
     // MARK: - Shared Books Navigation

--- a/Verse Reminder/Views/FirstTimeSetupView.swift
+++ b/Verse Reminder/Views/FirstTimeSetupView.swift
@@ -171,6 +171,7 @@ struct FirstTimeSetupView: View {
                 showWelcome = true
             }
         }
+        .navigationViewStyle(.stack)
     }
 
     private func save() {

--- a/Verse Reminder/Views/HomeView.swift
+++ b/Verse Reminder/Views/HomeView.swift
@@ -120,6 +120,7 @@ struct HomeView: View {
                 NavigationView { PrivacyPolicyView() }
             }
         }
+        .navigationViewStyle(.stack)
     }
 
     private func lastReadReference() -> (ref: String, verse: Int)? {

--- a/Verse Reminder/Views/NoteEditorView.swift
+++ b/Verse Reminder/Views/NoteEditorView.swift
@@ -24,6 +24,7 @@ struct NoteEditorView: View {
                     }
                 }
         }
+        .navigationViewStyle(.stack)
     }
 }
 

--- a/Verse Reminder/Views/StudyView.swift
+++ b/Verse Reminder/Views/StudyView.swift
@@ -93,6 +93,7 @@ struct StudyView: View {
             .navigationTitle("Study")
             .onAppear(perform: loadBookmarks)
         }
+        .navigationViewStyle(.stack)
     }
 
     private func referencePrefix(for id: String) -> String {


### PR DESCRIPTION
## Summary
- make iPad use the same tab layout as iPhone
- force stack navigation style so views use the full screen

## Testing
- `xcodebuild -list` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68703a5cceac832e9dac15dbc35f484b