### PR TITLE
Fix Books view layout on iPad

### DIFF
--- a/Verse Reminder/Views/ContentView.swift
+++ b/Verse Reminder/Views/ContentView.swift
@@ -21,6 +21,7 @@ struct ContentView: View {
                 .tag(AppTab.home)
 
             NavigationView { booksStack }
+                .navigationViewStyle(.stack)
                 .opacity(tabManager.selection == .books ? 1 : 0)
                 .animation(.easeInOut(duration: 0.3), value: tabManager.selection)
                 .tabItem {


### PR DESCRIPTION
## Summary
- keep the Books tab using a stack navigation style

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68703c64d150832ebfcfb9f6be8d9c96