### PR TITLE
Ensure fastlane snapshot supports new iPad Air

### DIFF
--- a/Verse ReminderUITests/SnapshotHelper.swift
+++ b/Verse ReminderUITests/SnapshotHelper.swift
@@ -268,8 +268,9 @@ private extension XCUIElementAttributes {
 
         let oldStatusBarSize = CGSize(width: deviceWidth, height: 20)
         let newStatusBarSize = CGSize(width: deviceWidth, height: 44)
+        let m3iPadStatusBarSize = CGSize(width: deviceWidth, height: 54)
 
-        return [oldStatusBarSize, newStatusBarSize].contains(frame.size)
+        return [oldStatusBarSize, newStatusBarSize, m3iPadStatusBarSize].contains(frame.size)
     }
 }
 
@@ -310,4 +311,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.30]
+// SnapshotHelperVersion [1.31]


### PR DESCRIPTION
## Summary
- handle the taller status bar on M3 iPads in SnapshotHelper
- bump snapshot helper version

## Testing
- `bundle install`
- `bundle exec fastlane ios screenshots` *(fails: uninitialized constant FastlaneCore::UpdateChecker)*

------
https://chatgpt.com/codex/tasks/task_e_68706fa72ebc832e942975f474249edb