### PR TITLE
Reset simulators before screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+.bundle/

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,6 +18,7 @@ default_platform(:ios)
 platform :ios do
   desc "Take screenshots for the App Store"
   lane :screenshots do
+    sh("xcrun simctl shutdown all && xcrun simctl erase all")
     capture_screenshots
   end
 end

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -8,3 +8,4 @@ devices([
 languages(["en-US"])
 
 clear_previous_screenshots(true)
+erase_simulator true


### PR DESCRIPTION
## Summary
- reset iOS simulators before taking screenshots
- allow vendored dependencies to be ignored

## Testing
- `bundle exec fastlane ios screenshots` *(fails: xcrun not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871438998a4832ead073000a3dcbc24